### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Complete end-to-end training framework designed for maximum efficiency:
 | Model                  | #Vision Param | #Language Param | #Total Param | HF Link                                                                      |
 |------------------------|---------------|-----------------|--------------|------------------------------------------------------------------------------|
 | LLaVA-OV-1.5-4B-Instruct      | 0.3B          | 4.4B            | 4.7B         | [🤗 link]()                |
-| LLaVA-OV-1.5-8B-Instruct      | 0.3B          | 8.2B            | 8.5B         | [🤗 link](https://huggingface.co/lmms-lab/LLaVA-One-Vision-1.5-8B-Instruct)                |
+| LLaVA-OV-1.5-8B-Instruct      | 0.3B          | 8.2B            | 8.5B         | [🤗 link](https://huggingface.co/lmms-lab/LLaVA-OneVision-1.5-8B-Instruct) |
 
 
 ## Dataset
@@ -45,7 +45,7 @@ Complete end-to-end training framework designed for maximum efficiency:
 | Description | Link |
 |-------------|------|
 | Mid-training data for LLaVA-OneVision-1.5 | [🤗 Download (Uploading!)](https://huggingface.co/datasets/lmms-lab/LLaVA-One-Vision-1.5-Mid-Training-85M) |
-| SFT data for LLaVA-OneVision-1.5 | [🤗 Download (Uploading!)](https://huggingface.co/datasets/lmms-lab/LLaVA-One-Vision-1.5-Insturct-26M) |
+| SFT data for LLaVA-OneVision-1.5 | [🤗 Download (Uploading!)](https://huggingface.co/datasets/lmms-lab/LLaVA-OneVision-1.5-Insturct-Data) |
 
 
 ## Evaluation Results


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Corrected HuggingFace links in the README for the 8B Instruct model and SFT dataset, updating paths (dash removal and dataset suffix) to canonical URLs.
  - Mid-training data link remains unchanged; all other content intact.
  - No functional changes; improves navigation and reduces broken links for users accessing models and datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->