### PR TITLE
Remove duplicate dependency `py-cpuinfo` libraries.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ protobuf==3.20.2
 py-cpuinfo==9.0.0
 qwen_vl_utils
 sentencepiece==0.1.98
-py-cpuinfo==9.0.0
 tiktoken==0.5.2
 timm==1.0.3
 transformers==4.53.1


### PR DESCRIPTION
It's a minor change, but it might improve readability.