### PR TITLE
fix(merge_model): use torch_dtype for MLCDVisionModel and remove invalid device_map from CLIPImageProcessor

### DIFF
--- a/ds/merge_model.py
+++ b/ds/merge_model.py
@@ -260,8 +260,8 @@ def validate_vit_consistency(model, vit_path, img_path):
     sample_image = Image.open(BytesIO(response.content)).convert("RGB")
     sample_image = sample_image.resize((560, 560))
     
-    rice_model = MLCDVisionModel.from_pretrained(vit_path, device_map={"": f"cuda:{CUDA_DEVICE}"})
-    processor = CLIPImageProcessor.from_pretrained(vit_path, device_map={"": f"cuda:{CUDA_DEVICE}"}, use_fast=True)
+    rice_model = MLCDVisionModel.from_pretrained(vit_path, device_map={"": f"cuda:{CUDA_DEVICE}"}, torch_dtype=torch.float32)
+    processor = CLIPImageProcessor.from_pretrained(vit_path, use_fast=True)
     rice_inputs = processor.preprocess(images=sample_image, return_tensors="pt").to(dtype=model.dtype, device=rice_model.device)
         
     rice_model = rice_model.eval()


### PR DESCRIPTION
## Problem

Two bugs in `validate_vit_consistency()` introduced by #52 and only partially addressed in #88:

1. **`MLCDVisionModel.from_pretrained`** — missing `torch_dtype=torch.float32`. The original code used `torch_dtype=` correctly; #52 changed it to `dtype=` (silently ignored by `from_pretrained`); #88 removed the param entirely, losing the explicit float32 cast.

2. **`CLIPImageProcessor.from_pretrained`** — still has `device_map=...` after #88. `CLIPImageProcessor` is a `ProcessorMixin`, not a `PreTrainedModel`; `device_map` is not a valid argument and raises `TypeError` at runtime.

## Fix

```python
# before
rice_model = MLCDVisionModel.from_pretrained(vit_path, device_map={"": f"cuda:{CUDA_DEVICE}"})
processor  = CLIPImageProcessor.from_pretrained(vit_path, device_map={"": f"cuda:{CUDA_DEVICE}"}, use_fast=True)

# after
rice_model = MLCDVisionModel.from_pretrained(vit_path, device_map={"": f"cuda:{CUDA_DEVICE}"}, torch_dtype=torch.float32)
processor  = CLIPImageProcessor.from_pretrained(vit_path, use_fast=True)
```