### PR TITLE
Refine codec sampling figures and improve README layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,9 @@ And unlike most "open" releases, *everything* ships alongside them: encoder weig
   </picture>
 </p>
 
-<details>
-<summary>Click to view Figure 4: codec-aligned sampling vs. uniform frame sampling.</summary>
-
 <p align="center">
-  <img src="asset/method_codec_vs_frame.svg" width="100%" alt="Codec-aligned sampling compared with uniform frame sampling across video benchmarks">
+  <img src="asset/method_codec_vs_frame.svg" width="100%" alt="Figure 4: codec-aligned sampling compared with uniform frame sampling across video benchmarks">
 </p>
-
-</details>
 
 
 ## Method

--- a/asset/method_codec_vs_frame.svg
+++ b/asset/method_codec_vs_frame.svg
@@ -1,371 +1,233 @@
-<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1289.43pt" height="965pt" viewBox="0 0 1289.43 965" role="img" aria-labelledby="title desc">
+<?xml version='1.0' encoding='utf-8'?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="580" viewBox="0 0 1100 580" role="img" aria-labelledby="title desc">
 <title id="title">Codec vs Frame Sampling</title>
 <desc id="desc">Table-style small multiples comparing codec-aligned sampling against uniform frame sampling across seven video benchmarks.</desc>
 <defs>
-<style><![CDATA[@keyframes cvf-fade{from{opacity:0}to{opacity:1}}
+<style><![CDATA[
+@keyframes cvf-fade{from{opacity:0}to{opacity:1}}
 @keyframes cvf-draw{from{stroke-dashoffset:900}to{stroke-dashoffset:0}}
-g[id^='cvf-panel-']{animation:cvf-fade .4s ease-out both}
+g[id^="cvf-panel-"]{animation:cvf-fade .4s ease-out both}
 .codec-line{stroke-dasharray:900;animation:cvf-draw 1.2s ease-out .35s both}
-.caption-a{font:600 18px 'DejaVu Serif', 'Nimbus Roman', 'Times New Roman', 'Times', serif;fill:#6a737d}
-.caption-b{font:600 18px 'DejaVu Serif', 'Nimbus Roman', 'Times New Roman', 'Times', serif;fill:#1a1a1a}
-.note{font:14px 'DejaVu Serif', 'Nimbus Roman', 'Times New Roman', 'Times', serif;fill:#4a5258}
-.head{font:600 15px 'DejaVu Serif', 'Nimbus Roman', 'Times New Roman', 'Times', serif;fill:#1a1a1a}
-.subhead{font:600 11.5px 'DejaVu Serif', 'Nimbus Roman', 'Times New Roman', 'Times', serif;fill:#6a737d;letter-spacing:0.02em}
-.num{font:600 13px 'DejaVu Serif', 'Nimbus Roman', 'Times New Roman', 'Times', serif;fill:#1a1a1a}
-.axis{stroke:#1a1a1a;stroke-width:.8}
-.grid{stroke:#d1d5da;stroke-width:.4;stroke-dasharray:2 2}
-.tick{font:11px 'DejaVu Serif', 'Nimbus Roman', 'Times New Roman', 'Times', serif;fill:#6a737d}
-.legend{font:13.5px 'DejaVu Serif', 'Nimbus Roman', 'Times New Roman', 'Times', serif;fill:#1a1a1a}
-.panel-title{font:600 16px 'DejaVu Serif', 'Nimbus Roman', 'Times New Roman', 'Times', serif;fill:#1a1a1a}
-.score{font:600 14px 'DejaVu Serif', 'Nimbus Roman', 'Times New Roman', 'Times', serif}
-.small{font:11.5px 'DejaVu Serif', 'Nimbus Roman', 'Times New Roman', 'Times', serif;fill:#6a737d}]]></style>
-<filter id="panel-shadow" x="-5%" y="-5%" width="110%" height="110%"><feDropShadow dx="0" dy="2" stdDeviation="4" flood-opacity="0.04"/></filter>
+.caption{font:600 13px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#1a1a1a}
+.caption-muted{fill:#6a737d}
+.panel-title{font:600 12px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#1a1a1a}
+.subhead{font:10.5px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#6a737d}
+.tick{font:10px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#6a737d}
+.score-codec{font:bold 11px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#1a1a1a}
+.score-frame{font:bold 11px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#6a737d}
+.axis{stroke:#1a1a1a;stroke-width:0.6}
+.grid{stroke:#eaecef;stroke-width:0.8}
+]]></style>
 </defs>
-<rect width="1289.43" height="965" fill="#ffffff"/>
-<text class="caption-a" x="43.47" y="40.8">Figure 4: </text>
-<text class="caption-b" x="125.0" y="40.8">Codec-aligned sampling vs. uniform frame sampling.</text>
-<rect x="46.26" y="58" width="22" height="14" fill="#fef3c7" stroke="#f0d878" stroke-width="1" rx="2"/>
-<text class="note" x="76" y="70">Codec advantage region</text>
-<line x1="236" y1="65" x2="276" y2="65" stroke="#1a1a1a" stroke-width="2"/>
-<circle cx="256" cy="65" r="3.5" fill="#1a1a1a"/>
-<text class="note" x="286" y="70">codec-aligned</text>
-<line x1="420" y1="65" x2="460" y2="65" stroke="#8c959f" stroke-width="1.5" stroke-dasharray="4 3"/>
-<circle cx="440" cy="65" r="3" fill="#fff" stroke="#6a737d" stroke-width="1.2"/>
-<text class="note" x="470" y="70">uniform frame</text>
-<line x1="46.26" y1="101" x2="1243.17" y2="101" stroke="#1a1a1a" stroke-width="1.2"/>
-<line x1="46.26" y1="116" x2="1243.17" y2="116" stroke="#e1e4e8" stroke-width="1"/>
-<g id="cvf-panel-0" transform="translate(46.26,150.00)" style="animation-delay:0.00s">
-<rect width="285" height="360" fill="#ffffff" stroke="#e1e4e8" stroke-width="1" rx="4" filter="url(#panel-shadow)"/>
-<rect x="0" y="0" width="285" height="42" fill="#f8f9fa" rx="4"/><path d="M0,42 L285,42" stroke="#e1e4e8" stroke-width="1"/>
-<text x="14" y="27" class="panel-title">TimeLens-QVHighlights</text>
-<text x="271" y="26" text-anchor="end" class="subhead">peak +26.6</text>
-<rect x="14" y="54" width="257" height="34" fill="#fef3c7" stroke="#f0d878" stroke-width="1" rx="3"/>
-<text x="26" y="76" class="subhead">4f Δ</text>
-<text x="83" y="76" class="num">+15.4</text>
-<text x="150" y="76" class="subhead">64f Δ</text>
-<text x="214" y="76" text-anchor="end" class="num">+1.8</text>
-<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid"/>
-<text x="41" y="297.0" text-anchor="end" class="tick">10</text>
-<line x1="48" y1="234.0" x2="238" y2="234.0" class="grid"/>
-<text x="41" y="237.0" text-anchor="end" class="tick">30</text>
-<line x1="48" y1="174.0" x2="238" y2="174.0" class="grid"/>
-<text x="41" y="177.0" text-anchor="end" class="tick">50</text>
-<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid"/>
-<text x="41" y="117.0" text-anchor="end" class="tick">70</text>
-<line x1="48.0" y1="114" x2="48.0" y2="294" class="grid"/>
-<text x="48.0" y="311" text-anchor="middle" class="tick">4</text>
-<line x1="95.5" y1="114" x2="95.5" y2="294" class="grid"/>
-<line x1="143.0" y1="114" x2="143.0" y2="294" class="grid"/>
-<text x="143.0" y="311" text-anchor="middle" class="tick">16</text>
-<line x1="190.5" y1="114" x2="190.5" y2="294" class="grid"/>
-<line x1="238.0" y1="114" x2="238.0" y2="294" class="grid"/>
-<text x="238.0" y="311" text-anchor="middle" class="tick">64</text>
-<polygon points="48.0,287.1 95.5,254.1 143.0,249.3 190.5,164.4 238.0,138.9 238.0,133.5 190.5,146.4 143.0,169.5 95.5,202.8 48.0,240.9" fill="#fef3c7" stroke="#f0d878" stroke-width="0.35" opacity="0.85"/>
-<line x1="48" y1="114" x2="48" y2="294" class="axis"/>
-<line x1="48" y1="294" x2="238" y2="294" class="axis"/>
-<polyline points="48.0,287.1 95.5,254.1 143.0,249.3 190.5,164.4 238.0,138.9" fill="none" stroke="#8c959f" stroke-width="1.5" stroke-dasharray="4 3"/>
-<polyline class="codec-line" points="48.0,240.9 95.5,202.8 143.0,169.5 190.5,146.4 238.0,133.5" fill="none" stroke="#1a1a1a" stroke-width="2.2"/>
-<circle cx="48.0" cy="287.1" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="95.5" cy="254.1" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="143.0" cy="249.3" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="190.5" cy="164.4" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="238.0" cy="138.9" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="48.0" cy="240.9" r="3.2" fill="#1a1a1a"/>
-<circle cx="95.5" cy="202.8" r="3.2" fill="#1a1a1a"/>
-<circle cx="143.0" cy="169.5" r="3.2" fill="#1a1a1a"/>
-<circle cx="190.5" cy="146.4" r="3.2" fill="#1a1a1a"/>
-<circle cx="238.0" cy="133.5" r="3.2" fill="#1a1a1a"/>
-<line x1="0" y1="318" x2="285" y2="318" stroke="#1a1a1a" stroke-width="0.45"/>
-<path d="M0,318 L142.5,318 L142.5,360 L4,360 A4,4 0 0 1 0,356 Z" fill="#fef3c7" stroke="#f0d878" stroke-width="0.5"/><path d="M0,318 L285,318" stroke="#e1e4e8" stroke-width="1"/>
-<path d="M142.5,318 L285,318 L285,356 A4,4 0 0 1 281,360 L142.5,360 Z" fill="#f3f5f7"/><path d="M142.5,318 L142.5,360" stroke="#e1e4e8" stroke-width="1"/>
-<text x="18" y="335" class="small">codec @ max</text>
-<text x="18" y="351" class="score" fill="#1a1a1a">63.5</text>
-<text x="160.5" y="335" class="small">frame @ max</text>
-<text x="160.5" y="351" class="score" fill="#4a5258">61.7</text>
+<rect width="1100" height="580" fill="#ffffff" />
+
+<line x1="36" y1="323" x2="1036" y2="323" stroke="#eaecef" stroke-width="0.6" /><line x1="266" y1="75" x2="266" y2="550" stroke="#eaecef" stroke-width="0.6" /><line x1="536" y1="75" x2="536" y2="550" stroke="#eaecef" stroke-width="0.6" /><line x1="806" y1="75" x2="806" y2="550" stroke="#eaecef" stroke-width="0.6" /><text class="caption" x="30" y="30"><tspan class="caption-muted">Figure 4: </tspan>Codec-aligned sampling vs. uniform frame sampling.</text>
+<g transform="translate(730, 26)">
+
+<line x1="0" y1="0" x2="30" y2="0" stroke="#1a1a1a" stroke-width="1.8" />
+<text class="tick" x="36" y="4">codec-aligned</text>
+
+<line x1="125" y1="0" x2="155" y2="0" stroke="#8c959f" stroke-width="1.3" stroke-dasharray="3 2" />
+<text class="tick" x="161" y="4">uniform frame</text>
+<rect x="250" y="-6" width="16" height="12" fill="#fef3c7" opacity="0.6" />
+<text class="tick" x="272" y="4">codec advantage</text>
 </g>
-<g id="cvf-panel-1" transform="translate(349.26,150.00)" style="animation-delay:0.08s">
-<rect width="285" height="360" fill="#ffffff" stroke="#e1e4e8" stroke-width="1" rx="4" filter="url(#panel-shadow)"/>
-<rect x="0" y="0" width="285" height="42" fill="#f8f9fa" rx="4"/><path d="M0,42 L285,42" stroke="#e1e4e8" stroke-width="1"/>
-<text x="14" y="27" class="panel-title">TimeLens-Charades-STA</text>
-<text x="271" y="26" text-anchor="end" class="subhead">peak +25.0</text>
-<rect x="14" y="54" width="257" height="34" fill="#fef3c7" stroke="#f0d878" stroke-width="1" rx="3"/>
-<text x="26" y="76" class="subhead">4f Δ</text>
-<text x="83" y="76" class="num">+25.0</text>
-<text x="150" y="76" class="subhead">64f Δ</text>
-<text x="214" y="76" text-anchor="end" class="num">-3.4</text>
-<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid"/>
-<text x="41" y="297.0" text-anchor="end" class="tick">15</text>
-<line x1="48" y1="204.0" x2="238" y2="204.0" class="grid"/>
-<text x="41" y="207.0" text-anchor="end" class="tick">35</text>
-<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid"/>
-<text x="41" y="117.0" text-anchor="end" class="tick">55</text>
-<line x1="48.0" y1="114" x2="48.0" y2="294" class="grid"/>
-<text x="48.0" y="311" text-anchor="middle" class="tick">4</text>
-<line x1="95.5" y1="114" x2="95.5" y2="294" class="grid"/>
-<line x1="143.0" y1="114" x2="143.0" y2="294" class="grid"/>
-<text x="143.0" y="311" text-anchor="middle" class="tick">16</text>
-<line x1="190.5" y1="114" x2="190.5" y2="294" class="grid"/>
-<line x1="238.0" y1="114" x2="238.0" y2="294" class="grid"/>
-<text x="238.0" y="311" text-anchor="middle" class="tick">64</text>
-<polygon points="48.0,283.2 95.5,194.6 143.0,145.1 190.5,122.6 238.0,120.8 238.0,136.0 190.5,137.0 143.0,132.0 95.5,144.6 48.0,170.7" fill="#fef3c7" stroke="#f0d878" stroke-width="0.35" opacity="0.85"/>
-<line x1="48" y1="114" x2="48" y2="294" class="axis"/>
-<line x1="48" y1="294" x2="238" y2="294" class="axis"/>
-<polyline points="48.0,283.2 95.5,194.6 143.0,145.1 190.5,122.6 238.0,120.8" fill="none" stroke="#8c959f" stroke-width="1.5" stroke-dasharray="4 3"/>
-<polyline class="codec-line" points="48.0,170.7 95.5,144.6 143.0,132.0 190.5,137.0 238.0,136.0" fill="none" stroke="#1a1a1a" stroke-width="2.2"/>
-<circle cx="48.0" cy="283.2" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="95.5" cy="194.6" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="143.0" cy="145.1" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="190.5" cy="122.6" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="238.0" cy="120.8" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="48.0" cy="170.7" r="3.2" fill="#1a1a1a"/>
-<circle cx="95.5" cy="144.6" r="3.2" fill="#1a1a1a"/>
-<circle cx="143.0" cy="132.0" r="3.2" fill="#1a1a1a"/>
-<circle cx="190.5" cy="137.0" r="3.2" fill="#1a1a1a"/>
-<circle cx="238.0" cy="136.0" r="3.2" fill="#1a1a1a"/>
-<line x1="0" y1="318" x2="285" y2="318" stroke="#1a1a1a" stroke-width="0.45"/>
-<path d="M0,318 L142.5,318 L142.5,360 L4,360 A4,4 0 0 1 0,356 Z" fill="#fef3c7" stroke="#f0d878" stroke-width="0.5"/><path d="M0,318 L285,318" stroke="#e1e4e8" stroke-width="1"/>
-<path d="M142.5,318 L285,318 L285,356 A4,4 0 0 1 281,360 L142.5,360 Z" fill="#f3f5f7"/><path d="M142.5,318 L142.5,360" stroke="#e1e4e8" stroke-width="1"/>
-<text x="18" y="335" class="small">codec @ max</text>
-<text x="18" y="351" class="score" fill="#1a1a1a">50.1</text>
-<text x="160.5" y="335" class="small">frame @ max</text>
-<text x="160.5" y="351" class="score" fill="#4a5258">53.5</text>
+<g id="cvf-panel-0" transform="translate(-12.00,-24.00)" style="animation-delay:0.00s">
+<text x="48" y="99" class="panel-title">TimeLens-QVHighlights</text>
+<text x="48" y="111" class="subhead">peak +26.6  ·  4f Δ +15.4  ·  64f Δ +1.8</text>
+
+<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid" />
+<text x="42" y="297.0" text-anchor="end" class="tick">10</text>
+
+<line x1="48" y1="234.0" x2="238" y2="234.0" class="grid" />
+<text x="42" y="237.0" text-anchor="end" class="tick">30</text>
+
+<line x1="48" y1="174.0" x2="238" y2="174.0" class="grid" />
+<text x="42" y="177.0" text-anchor="end" class="tick">50</text>
+
+<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid" />
+<text x="42" y="117.0" text-anchor="end" class="tick">70</text>
+<text x="48.0" y="316.0" text-anchor="middle" class="tick">4</text>
+<text x="143.0" y="316.0" text-anchor="middle" class="tick">16</text>
+<text x="238.0" y="316.0" text-anchor="middle" class="tick">64</text>
+<line class="grid" x1="48.0" y1="114" x2="48.0" y2="294" /><line class="grid" x1="143.0" y1="114" x2="143.0" y2="294" /><line class="grid" x1="238.0" y1="114" x2="238.0" y2="294" /><polygon points="48.0,287.1 95.5,254.1 143.0,249.3 190.5,164.4 238.0,138.9 238.0,133.5 190.5,146.4 143.0,169.5 95.5,202.8 48.0,240.9" fill="#fef3c7" opacity="0.4" />
+
+<line x1="48" y1="114" x2="48" y2="294" class="axis" />
+
+<line x1="48" y1="294" x2="238" y2="294" class="axis" />
+<polyline points="48.0,287.1 95.5,254.1 143.0,249.3 190.5,164.4 238.0,138.9" fill="none" stroke="#8c959f" stroke-width="1.3" stroke-dasharray="3 2" />
+<polyline class="codec-line" points="48.0,240.9 95.5,202.8 143.0,169.5 190.5,146.4 238.0,133.5" fill="none" stroke="#1a1a1a" stroke-width="1.8" />
+<text x="244" y="133.5" class="score-codec">63.5</text>
+<text x="244" y="146.9" class="score-frame">61.7</text>
 </g>
-<g id="cvf-panel-2" transform="translate(652.26,150.00)" style="animation-delay:0.16s">
-<rect width="285" height="360" fill="#ffffff" stroke="#e1e4e8" stroke-width="1" rx="4" filter="url(#panel-shadow)"/>
-<rect x="0" y="0" width="285" height="42" fill="#f8f9fa" rx="4"/><path d="M0,42 L285,42" stroke="#e1e4e8" stroke-width="1"/>
-<text x="14" y="27" class="panel-title">TimeLens-ActivityNet</text>
-<text x="271" y="26" text-anchor="end" class="subhead">peak +13.3</text>
-<rect x="14" y="54" width="257" height="34" fill="#fef3c7" stroke="#f0d878" stroke-width="1" rx="3"/>
-<text x="26" y="76" class="subhead">4f Δ</text>
-<text x="83" y="76" class="num">+11.1</text>
-<text x="150" y="76" class="subhead">64f Δ</text>
-<text x="214" y="76" text-anchor="end" class="num">+2.3</text>
-<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid"/>
-<text x="41" y="297.0" text-anchor="end" class="tick">10</text>
-<line x1="48" y1="234.0" x2="238" y2="234.0" class="grid"/>
-<text x="41" y="237.0" text-anchor="end" class="tick">25</text>
-<line x1="48" y1="174.0" x2="238" y2="174.0" class="grid"/>
-<text x="41" y="177.0" text-anchor="end" class="tick">40</text>
-<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid"/>
-<text x="41" y="117.0" text-anchor="end" class="tick">55</text>
-<line x1="48.0" y1="114" x2="48.0" y2="294" class="grid"/>
-<text x="48.0" y="311" text-anchor="middle" class="tick">4</text>
-<line x1="95.5" y1="114" x2="95.5" y2="294" class="grid"/>
-<line x1="143.0" y1="114" x2="143.0" y2="294" class="grid"/>
-<text x="143.0" y="311" text-anchor="middle" class="tick">16</text>
-<line x1="190.5" y1="114" x2="190.5" y2="294" class="grid"/>
-<line x1="238.0" y1="114" x2="238.0" y2="294" class="grid"/>
-<text x="238.0" y="311" text-anchor="middle" class="tick">64</text>
-<polygon points="48.0,286.0 95.5,260.0 143.0,221.6 190.5,174.4 238.0,138.4 238.0,129.2 190.5,144.0 143.0,171.6 95.5,206.8 48.0,241.6" fill="#fef3c7" stroke="#f0d878" stroke-width="0.35" opacity="0.85"/>
-<line x1="48" y1="114" x2="48" y2="294" class="axis"/>
-<line x1="48" y1="294" x2="238" y2="294" class="axis"/>
-<polyline points="48.0,286.0 95.5,260.0 143.0,221.6 190.5,174.4 238.0,138.4" fill="none" stroke="#8c959f" stroke-width="1.5" stroke-dasharray="4 3"/>
-<polyline class="codec-line" points="48.0,241.6 95.5,206.8 143.0,171.6 190.5,144.0 238.0,129.2" fill="none" stroke="#1a1a1a" stroke-width="2.2"/>
-<circle cx="48.0" cy="286.0" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="95.5" cy="260.0" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="143.0" cy="221.6" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="190.5" cy="174.4" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="238.0" cy="138.4" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="48.0" cy="241.6" r="3.2" fill="#1a1a1a"/>
-<circle cx="95.5" cy="206.8" r="3.2" fill="#1a1a1a"/>
-<circle cx="143.0" cy="171.6" r="3.2" fill="#1a1a1a"/>
-<circle cx="190.5" cy="144.0" r="3.2" fill="#1a1a1a"/>
-<circle cx="238.0" cy="129.2" r="3.2" fill="#1a1a1a"/>
-<line x1="0" y1="318" x2="285" y2="318" stroke="#1a1a1a" stroke-width="0.45"/>
-<path d="M0,318 L142.5,318 L142.5,360 L4,360 A4,4 0 0 1 0,356 Z" fill="#fef3c7" stroke="#f0d878" stroke-width="0.5"/><path d="M0,318 L285,318" stroke="#e1e4e8" stroke-width="1"/>
-<path d="M142.5,318 L285,318 L285,356 A4,4 0 0 1 281,360 L142.5,360 Z" fill="#f3f5f7"/><path d="M142.5,318 L142.5,360" stroke="#e1e4e8" stroke-width="1"/>
-<text x="18" y="335" class="small">codec @ max</text>
-<text x="18" y="351" class="score" fill="#1a1a1a">51.2</text>
-<text x="160.5" y="335" class="small">frame @ max</text>
-<text x="160.5" y="351" class="score" fill="#4a5258">48.9</text>
+<g id="cvf-panel-1" transform="translate(258.00,-24.00)" style="animation-delay:0.08s">
+<text x="48" y="99" class="panel-title">TimeLens-Charades-STA</text>
+<text x="48" y="111" class="subhead">peak +25.0  ·  4f Δ +25.0  ·  64f Δ -3.4</text>
+
+<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid" />
+<text x="42" y="297.0" text-anchor="end" class="tick">15</text>
+
+<line x1="48" y1="204.0" x2="238" y2="204.0" class="grid" />
+<text x="42" y="207.0" text-anchor="end" class="tick">35</text>
+
+<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid" />
+<text x="42" y="117.0" text-anchor="end" class="tick">55</text>
+<text x="48.0" y="316.0" text-anchor="middle" class="tick">4</text>
+<text x="143.0" y="316.0" text-anchor="middle" class="tick">16</text>
+<text x="238.0" y="316.0" text-anchor="middle" class="tick">64</text>
+<line class="grid" x1="48.0" y1="114" x2="48.0" y2="294" /><line class="grid" x1="143.0" y1="114" x2="143.0" y2="294" /><line class="grid" x1="238.0" y1="114" x2="238.0" y2="294" /><polygon points="48.0,283.2 95.5,194.6 143.0,145.1 190.5,122.6 238.0,120.8 238.0,136.0 190.5,137.0 143.0,132.0 95.5,144.6 48.0,170.7" fill="#fef3c7" opacity="0.4" />
+
+<line x1="48" y1="114" x2="48" y2="294" class="axis" />
+
+<line x1="48" y1="294" x2="238" y2="294" class="axis" />
+<polyline points="48.0,283.2 95.5,194.6 143.0,145.1 190.5,122.6 238.0,120.8" fill="none" stroke="#8c959f" stroke-width="1.3" stroke-dasharray="3 2" />
+<polyline class="codec-line" points="48.0,170.7 95.5,144.6 143.0,132.0 190.5,137.0 238.0,136.0" fill="none" stroke="#1a1a1a" stroke-width="1.8" />
+<text x="244" y="140.0" class="score-codec">50.1</text>
+<text x="244" y="124.8" class="score-frame">53.5</text>
 </g>
-<g id="cvf-panel-3" transform="translate(955.26,150.00)" style="animation-delay:0.24s">
-<rect width="285" height="360" fill="#ffffff" stroke="#e1e4e8" stroke-width="1" rx="4" filter="url(#panel-shadow)"/>
-<rect x="0" y="0" width="285" height="42" fill="#f8f9fa" rx="4"/><path d="M0,42 L285,42" stroke="#e1e4e8" stroke-width="1"/>
-<text x="14" y="27" class="panel-title">LVBench</text>
-<text x="271" y="26" text-anchor="end" class="subhead">peak +2.0</text>
-<rect x="14" y="54" width="257" height="34" fill="#fef3c7" stroke="#f0d878" stroke-width="1" rx="3"/>
-<text x="26" y="76" class="subhead">16f Δ</text>
-<text x="83" y="76" class="num">+2.0</text>
-<text x="150" y="76" class="subhead">128f Δ</text>
-<text x="214" y="76" text-anchor="end" class="num">+1.8</text>
-<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid"/>
-<text x="41" y="297.0" text-anchor="end" class="tick">36</text>
-<line x1="48" y1="204.0" x2="238" y2="204.0" class="grid"/>
-<text x="41" y="207.0" text-anchor="end" class="tick">44</text>
-<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid"/>
-<text x="41" y="117.0" text-anchor="end" class="tick">52</text>
-<line x1="48.0" y1="114" x2="48.0" y2="294" class="grid"/>
-<text x="48.0" y="311" text-anchor="middle" class="tick">16</text>
-<line x1="111.3" y1="114" x2="111.3" y2="294" class="grid"/>
-<line x1="174.7" y1="114" x2="174.7" y2="294" class="grid"/>
-<text x="174.7" y="311" text-anchor="middle" class="tick">64</text>
-<line x1="238.0" y1="114" x2="238.0" y2="294" class="grid"/>
-<text x="238.0" y="311" text-anchor="middle" class="tick">128</text>
-<polygon points="48.0,261.4 111.3,231.0 174.7,186.0 238.0,162.4 238.0,142.1 174.7,169.1 111.3,216.4 48.0,238.9" fill="#fef3c7" stroke="#f0d878" stroke-width="0.35" opacity="0.85"/>
-<line x1="48" y1="114" x2="48" y2="294" class="axis"/>
-<line x1="48" y1="294" x2="238" y2="294" class="axis"/>
-<polyline points="48.0,261.4 111.3,231.0 174.7,186.0 238.0,162.4" fill="none" stroke="#8c959f" stroke-width="1.5" stroke-dasharray="4 3"/>
-<polyline class="codec-line" points="48.0,238.9 111.3,216.4 174.7,169.1 238.0,142.1" fill="none" stroke="#1a1a1a" stroke-width="2.2"/>
-<circle cx="48.0" cy="261.4" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="111.3" cy="231.0" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="174.7" cy="186.0" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="238.0" cy="162.4" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="48.0" cy="238.9" r="3.2" fill="#1a1a1a"/>
-<circle cx="111.3" cy="216.4" r="3.2" fill="#1a1a1a"/>
-<circle cx="174.7" cy="169.1" r="3.2" fill="#1a1a1a"/>
-<circle cx="238.0" cy="142.1" r="3.2" fill="#1a1a1a"/>
-<line x1="0" y1="318" x2="285" y2="318" stroke="#1a1a1a" stroke-width="0.45"/>
-<path d="M0,318 L142.5,318 L142.5,360 L4,360 A4,4 0 0 1 0,356 Z" fill="#fef3c7" stroke="#f0d878" stroke-width="0.5"/><path d="M0,318 L285,318" stroke="#e1e4e8" stroke-width="1"/>
-<path d="M142.5,318 L285,318 L285,356 A4,4 0 0 1 281,360 L142.5,360 Z" fill="#f3f5f7"/><path d="M142.5,318 L142.5,360" stroke="#e1e4e8" stroke-width="1"/>
-<text x="18" y="335" class="small">codec @ max</text>
-<text x="18" y="351" class="score" fill="#1a1a1a">49.5</text>
-<text x="160.5" y="335" class="small">frame @ max</text>
-<text x="160.5" y="351" class="score" fill="#4a5258">47.7</text>
+<g id="cvf-panel-2" transform="translate(528.00,-24.00)" style="animation-delay:0.16s">
+<text x="48" y="99" class="panel-title">TimeLens-ActivityNet</text>
+<text x="48" y="111" class="subhead">peak +13.3  ·  4f Δ +11.1  ·  64f Δ +2.3</text>
+
+<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid" />
+<text x="42" y="297.0" text-anchor="end" class="tick">10</text>
+
+<line x1="48" y1="234.0" x2="238" y2="234.0" class="grid" />
+<text x="42" y="237.0" text-anchor="end" class="tick">25</text>
+
+<line x1="48" y1="174.0" x2="238" y2="174.0" class="grid" />
+<text x="42" y="177.0" text-anchor="end" class="tick">40</text>
+
+<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid" />
+<text x="42" y="117.0" text-anchor="end" class="tick">55</text>
+<text x="48.0" y="316.0" text-anchor="middle" class="tick">4</text>
+<text x="143.0" y="316.0" text-anchor="middle" class="tick">16</text>
+<text x="238.0" y="316.0" text-anchor="middle" class="tick">64</text>
+<line class="grid" x1="48.0" y1="114" x2="48.0" y2="294" /><line class="grid" x1="143.0" y1="114" x2="143.0" y2="294" /><line class="grid" x1="238.0" y1="114" x2="238.0" y2="294" /><polygon points="48.0,286.0 95.5,260.0 143.0,221.6 190.5,174.4 238.0,138.4 238.0,129.2 190.5,144.0 143.0,171.6 95.5,206.8 48.0,241.6" fill="#fef3c7" opacity="0.4" />
+
+<line x1="48" y1="114" x2="48" y2="294" class="axis" />
+
+<line x1="48" y1="294" x2="238" y2="294" class="axis" />
+<polyline points="48.0,286.0 95.5,260.0 143.0,221.6 190.5,174.4 238.0,138.4" fill="none" stroke="#8c959f" stroke-width="1.3" stroke-dasharray="3 2" />
+<polyline class="codec-line" points="48.0,241.6 95.5,206.8 143.0,171.6 190.5,144.0 238.0,129.2" fill="none" stroke="#1a1a1a" stroke-width="1.8" />
+<text x="244" y="129.2" class="score-codec">51.2</text>
+<text x="244" y="146.4" class="score-frame">48.9</text>
 </g>
-<g id="cvf-panel-4" transform="translate(46.26,556.00)" style="animation-delay:0.32s">
-<rect width="285" height="360" fill="#ffffff" stroke="#e1e4e8" stroke-width="1" rx="4" filter="url(#panel-shadow)"/>
-<rect x="0" y="0" width="285" height="42" fill="#f8f9fa" rx="4"/><path d="M0,42 L285,42" stroke="#e1e4e8" stroke-width="1"/>
-<text x="14" y="27" class="panel-title">VideoMME-Long-Sub</text>
-<text x="271" y="26" text-anchor="end" class="subhead">peak +7.2</text>
-<rect x="14" y="54" width="257" height="34" fill="#fef3c7" stroke="#f0d878" stroke-width="1" rx="3"/>
-<text x="26" y="76" class="subhead">8f Δ</text>
-<text x="83" y="76" class="num">+6.2</text>
-<text x="150" y="76" class="subhead">128f Δ</text>
-<text x="214" y="76" text-anchor="end" class="num">+4.4</text>
-<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid"/>
-<text x="41" y="297.0" text-anchor="end" class="tick">50</text>
-<line x1="48" y1="204.0" x2="238" y2="204.0" class="grid"/>
-<text x="41" y="207.0" text-anchor="end" class="tick">60</text>
-<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid"/>
-<text x="41" y="117.0" text-anchor="end" class="tick">70</text>
-<line x1="48.0" y1="114" x2="48.0" y2="294" class="grid"/>
-<text x="48.0" y="311" text-anchor="middle" class="tick">8</text>
-<line x1="95.5" y1="114" x2="95.5" y2="294" class="grid"/>
-<text x="95.5" y="311" text-anchor="middle" class="tick">16</text>
-<line x1="143.0" y1="114" x2="143.0" y2="294" class="grid"/>
-<line x1="190.5" y1="114" x2="190.5" y2="294" class="grid"/>
-<text x="190.5" y="311" text-anchor="middle" class="tick">64</text>
-<line x1="238.0" y1="114" x2="238.0" y2="294" class="grid"/>
-<text x="238.0" y="311" text-anchor="middle" class="tick">128</text>
-<polygon points="48.0,287.7 95.5,249.0 143.0,228.3 190.5,211.2 238.0,175.2 238.0,135.6 190.5,146.4 143.0,176.1 95.5,211.2 48.0,231.9" fill="#fef3c7" stroke="#f0d878" stroke-width="0.35" opacity="0.85"/>
-<line x1="48" y1="114" x2="48" y2="294" class="axis"/>
-<line x1="48" y1="294" x2="238" y2="294" class="axis"/>
-<polyline points="48.0,287.7 95.5,249.0 143.0,228.3 190.5,211.2 238.0,175.2" fill="none" stroke="#8c959f" stroke-width="1.5" stroke-dasharray="4 3"/>
-<polyline class="codec-line" points="48.0,231.9 95.5,211.2 143.0,176.1 190.5,146.4 238.0,135.6" fill="none" stroke="#1a1a1a" stroke-width="2.2"/>
-<circle cx="48.0" cy="287.7" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="95.5" cy="249.0" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="143.0" cy="228.3" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="190.5" cy="211.2" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="238.0" cy="175.2" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="48.0" cy="231.9" r="3.2" fill="#1a1a1a"/>
-<circle cx="95.5" cy="211.2" r="3.2" fill="#1a1a1a"/>
-<circle cx="143.0" cy="176.1" r="3.2" fill="#1a1a1a"/>
-<circle cx="190.5" cy="146.4" r="3.2" fill="#1a1a1a"/>
-<circle cx="238.0" cy="135.6" r="3.2" fill="#1a1a1a"/>
-<line x1="0" y1="318" x2="285" y2="318" stroke="#1a1a1a" stroke-width="0.45"/>
-<path d="M0,318 L142.5,318 L142.5,360 L4,360 A4,4 0 0 1 0,356 Z" fill="#fef3c7" stroke="#f0d878" stroke-width="0.5"/><path d="M0,318 L285,318" stroke="#e1e4e8" stroke-width="1"/>
-<path d="M142.5,318 L285,318 L285,356 A4,4 0 0 1 281,360 L142.5,360 Z" fill="#f3f5f7"/><path d="M142.5,318 L142.5,360" stroke="#e1e4e8" stroke-width="1"/>
-<text x="18" y="335" class="small">codec @ max</text>
-<text x="18" y="351" class="score" fill="#1a1a1a">67.6</text>
-<text x="160.5" y="335" class="small">frame @ max</text>
-<text x="160.5" y="351" class="score" fill="#4a5258">63.2</text>
+<g id="cvf-panel-3" transform="translate(798.00,-24.00)" style="animation-delay:0.24s">
+<text x="48" y="99" class="panel-title">LVBench</text>
+<text x="48" y="111" class="subhead">peak +2.0  ·  16f Δ +2.0  ·  128f Δ +1.8</text>
+
+<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid" />
+<text x="42" y="297.0" text-anchor="end" class="tick">36</text>
+
+<line x1="48" y1="204.0" x2="238" y2="204.0" class="grid" />
+<text x="42" y="207.0" text-anchor="end" class="tick">44</text>
+
+<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid" />
+<text x="42" y="117.0" text-anchor="end" class="tick">52</text>
+<text x="48.0" y="316.0" text-anchor="middle" class="tick">16</text>
+<text x="174.7" y="316.0" text-anchor="middle" class="tick">64</text>
+<text x="238.0" y="316.0" text-anchor="middle" class="tick">128</text>
+<line class="grid" x1="48.0" y1="114" x2="48.0" y2="294" /><line class="grid" x1="174.7" y1="114" x2="174.7" y2="294" /><line class="grid" x1="238.0" y1="114" x2="238.0" y2="294" /><polygon points="48.0,261.4 111.3,231.0 174.7,186.0 238.0,162.4 238.0,142.1 174.7,169.1 111.3,216.4 48.0,238.9" fill="#fef3c7" opacity="0.4" />
+
+<line x1="48" y1="114" x2="48" y2="294" class="axis" />
+
+<line x1="48" y1="294" x2="238" y2="294" class="axis" />
+<polyline points="48.0,261.4 111.3,231.0 174.7,186.0 238.0,162.4" fill="none" stroke="#8c959f" stroke-width="1.3" stroke-dasharray="3 2" />
+<polyline class="codec-line" points="48.0,238.9 111.3,216.4 174.7,169.1 238.0,142.1" fill="none" stroke="#1a1a1a" stroke-width="1.8" />
+<text x="244" y="146.1" class="score-codec">49.5</text>
+<text x="244" y="166.4" class="score-frame">47.7</text>
 </g>
-<g id="cvf-panel-5" transform="translate(349.26,556.00)" style="animation-delay:0.40s">
-<rect width="285" height="360" fill="#ffffff" stroke="#e1e4e8" stroke-width="1" rx="4" filter="url(#panel-shadow)"/>
-<rect x="0" y="0" width="285" height="42" fill="#f8f9fa" rx="4"/><path d="M0,42 L285,42" stroke="#e1e4e8" stroke-width="1"/>
-<text x="14" y="27" class="panel-title">VideoEval-Pro</text>
-<text x="271" y="26" text-anchor="end" class="subhead">peak +3.4</text>
-<rect x="14" y="54" width="257" height="34" fill="#fef3c7" stroke="#f0d878" stroke-width="1" rx="3"/>
-<text x="26" y="76" class="subhead">8f Δ</text>
-<text x="83" y="76" class="num">+3.1</text>
-<text x="150" y="76" class="subhead">128f Δ</text>
-<text x="214" y="76" text-anchor="end" class="num">+1.5</text>
-<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid"/>
-<text x="41" y="297.0" text-anchor="end" class="tick">42</text>
-<line x1="48" y1="204.0" x2="238" y2="204.0" class="grid"/>
-<text x="41" y="207.0" text-anchor="end" class="tick">50</text>
-<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid"/>
-<text x="41" y="117.0" text-anchor="end" class="tick">58</text>
-<line x1="48.0" y1="114" x2="48.0" y2="294" class="grid"/>
-<text x="48.0" y="311" text-anchor="middle" class="tick">8</text>
-<line x1="95.5" y1="114" x2="95.5" y2="294" class="grid"/>
-<text x="95.5" y="311" text-anchor="middle" class="tick">16</text>
-<line x1="143.0" y1="114" x2="143.0" y2="294" class="grid"/>
-<line x1="190.5" y1="114" x2="190.5" y2="294" class="grid"/>
-<text x="190.5" y="311" text-anchor="middle" class="tick">64</text>
-<line x1="238.0" y1="114" x2="238.0" y2="294" class="grid"/>
-<text x="238.0" y="311" text-anchor="middle" class="tick">128</text>
-<polygon points="48.0,281.6 95.5,262.5 143.0,219.8 190.5,178.1 238.0,159.0 238.0,142.1 190.5,162.4 143.0,188.2 95.5,224.2 48.0,246.7" fill="#fef3c7" stroke="#f0d878" stroke-width="0.35" opacity="0.85"/>
-<line x1="48" y1="114" x2="48" y2="294" class="axis"/>
-<line x1="48" y1="294" x2="238" y2="294" class="axis"/>
-<polyline points="48.0,281.6 95.5,262.5 143.0,219.8 190.5,178.1 238.0,159.0" fill="none" stroke="#8c959f" stroke-width="1.5" stroke-dasharray="4 3"/>
-<polyline class="codec-line" points="48.0,246.7 95.5,224.2 143.0,188.2 190.5,162.4 238.0,142.1" fill="none" stroke="#1a1a1a" stroke-width="2.2"/>
-<circle cx="48.0" cy="281.6" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="95.5" cy="262.5" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="143.0" cy="219.8" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="190.5" cy="178.1" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="238.0" cy="159.0" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="48.0" cy="246.7" r="3.2" fill="#1a1a1a"/>
-<circle cx="95.5" cy="224.2" r="3.2" fill="#1a1a1a"/>
-<circle cx="143.0" cy="188.2" r="3.2" fill="#1a1a1a"/>
-<circle cx="190.5" cy="162.4" r="3.2" fill="#1a1a1a"/>
-<circle cx="238.0" cy="142.1" r="3.2" fill="#1a1a1a"/>
-<line x1="0" y1="318" x2="285" y2="318" stroke="#1a1a1a" stroke-width="0.45"/>
-<path d="M0,318 L142.5,318 L142.5,360 L4,360 A4,4 0 0 1 0,356 Z" fill="#fef3c7" stroke="#f0d878" stroke-width="0.5"/><path d="M0,318 L285,318" stroke="#e1e4e8" stroke-width="1"/>
-<path d="M142.5,318 L285,318 L285,356 A4,4 0 0 1 281,360 L142.5,360 Z" fill="#f3f5f7"/><path d="M142.5,318 L142.5,360" stroke="#e1e4e8" stroke-width="1"/>
-<text x="18" y="335" class="small">codec @ max</text>
-<text x="18" y="351" class="score" fill="#1a1a1a">55.5</text>
-<text x="160.5" y="335" class="small">frame @ max</text>
-<text x="160.5" y="351" class="score" fill="#4a5258">54.0</text>
+<g id="cvf-panel-4" transform="translate(-12.00,256.00)" style="animation-delay:0.32s">
+<text x="48" y="99" class="panel-title">VideoMME-Long-Sub</text>
+<text x="48" y="111" class="subhead">peak +7.2  ·  8f Δ +6.2  ·  128f Δ +4.4</text>
+
+<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid" />
+<text x="42" y="297.0" text-anchor="end" class="tick">50</text>
+
+<line x1="48" y1="204.0" x2="238" y2="204.0" class="grid" />
+<text x="42" y="207.0" text-anchor="end" class="tick">60</text>
+
+<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid" />
+<text x="42" y="117.0" text-anchor="end" class="tick">70</text>
+<text x="48.0" y="316.0" text-anchor="middle" class="tick">8</text>
+<text x="95.5" y="316.0" text-anchor="middle" class="tick">16</text>
+<text x="190.5" y="316.0" text-anchor="middle" class="tick">64</text>
+<text x="238.0" y="316.0" text-anchor="middle" class="tick">128</text>
+<line class="grid" x1="48.0" y1="114" x2="48.0" y2="294" /><line class="grid" x1="95.5" y1="114" x2="95.5" y2="294" /><line class="grid" x1="190.5" y1="114" x2="190.5" y2="294" /><line class="grid" x1="238.0" y1="114" x2="238.0" y2="294" /><polygon points="48.0,287.7 95.5,249.0 143.0,228.3 190.5,211.2 238.0,175.2 238.0,135.6 190.5,146.4 143.0,176.1 95.5,211.2 48.0,231.9" fill="#fef3c7" opacity="0.4" />
+
+<line x1="48" y1="114" x2="48" y2="294" class="axis" />
+
+<line x1="48" y1="294" x2="238" y2="294" class="axis" />
+<polyline points="48.0,287.7 95.5,249.0 143.0,228.3 190.5,211.2 238.0,175.2" fill="none" stroke="#8c959f" stroke-width="1.3" stroke-dasharray="3 2" />
+<polyline class="codec-line" points="48.0,231.9 95.5,211.2 143.0,176.1 190.5,146.4 238.0,135.6" fill="none" stroke="#1a1a1a" stroke-width="1.8" />
+<text x="244" y="139.6" class="score-codec">67.6</text>
+<text x="244" y="179.2" class="score-frame">63.2</text>
 </g>
-<g id="cvf-panel-6" transform="translate(652.26,556.00)" style="animation-delay:0.48s">
-<rect width="285" height="360" fill="#ffffff" stroke="#e1e4e8" stroke-width="1" rx="4" filter="url(#panel-shadow)"/>
-<rect x="0" y="0" width="285" height="42" fill="#f8f9fa" rx="4"/><path d="M0,42 L285,42" stroke="#e1e4e8" stroke-width="1"/>
-<text x="14" y="27" class="panel-title">OV-Rope</text>
-<text x="271" y="26" text-anchor="end" class="subhead">peak +21.4</text>
-<rect x="14" y="54" width="257" height="34" fill="#fef3c7" stroke="#f0d878" stroke-width="1" rx="3"/>
-<text x="26" y="76" class="subhead">16f Δ</text>
-<text x="83" y="76" class="num">+2.8</text>
-<text x="150" y="76" class="subhead">128f Δ</text>
-<text x="214" y="76" text-anchor="end" class="num">+19.0</text>
-<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid"/>
-<text x="41" y="297.0" text-anchor="end" class="tick">35</text>
-<line x1="48" y1="234.0" x2="238" y2="234.0" class="grid"/>
-<text x="41" y="237.0" text-anchor="end" class="tick">45</text>
-<line x1="48" y1="174.0" x2="238" y2="174.0" class="grid"/>
-<text x="41" y="177.0" text-anchor="end" class="tick">55</text>
-<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid"/>
-<text x="41" y="117.0" text-anchor="end" class="tick">65</text>
-<line x1="48.0" y1="114" x2="48.0" y2="294" class="grid"/>
-<text x="48.0" y="311" text-anchor="middle" class="tick">16</text>
-<line x1="111.3" y1="114" x2="111.3" y2="294" class="grid"/>
-<line x1="174.7" y1="114" x2="174.7" y2="294" class="grid"/>
-<text x="174.7" y="311" text-anchor="middle" class="tick">64</text>
-<line x1="238.0" y1="114" x2="238.0" y2="294" class="grid"/>
-<text x="238.0" y="311" text-anchor="middle" class="tick">128</text>
-<polygon points="48.0,279.6 111.3,286.8 174.7,277.8 238.0,247.2 238.0,133.2 174.7,149.4 111.3,202.2 48.0,262.8" fill="#fef3c7" stroke="#f0d878" stroke-width="0.35" opacity="0.85"/>
-<line x1="48" y1="114" x2="48" y2="294" class="axis"/>
-<line x1="48" y1="294" x2="238" y2="294" class="axis"/>
-<polyline points="48.0,279.6 111.3,286.8 174.7,277.8 238.0,247.2" fill="none" stroke="#8c959f" stroke-width="1.5" stroke-dasharray="4 3"/>
-<polyline class="codec-line" points="48.0,262.8 111.3,202.2 174.7,149.4 238.0,133.2" fill="none" stroke="#1a1a1a" stroke-width="2.2"/>
-<circle cx="48.0" cy="279.6" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="111.3" cy="286.8" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="174.7" cy="277.8" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="238.0" cy="247.2" r="2.7" fill="#ffffff" stroke="#6a737d" stroke-width="1"/>
-<circle cx="48.0" cy="262.8" r="3.2" fill="#1a1a1a"/>
-<circle cx="111.3" cy="202.2" r="3.2" fill="#1a1a1a"/>
-<circle cx="174.7" cy="149.4" r="3.2" fill="#1a1a1a"/>
-<circle cx="238.0" cy="133.2" r="3.2" fill="#1a1a1a"/>
-<line x1="0" y1="318" x2="285" y2="318" stroke="#1a1a1a" stroke-width="0.45"/>
-<path d="M0,318 L142.5,318 L142.5,360 L4,360 A4,4 0 0 1 0,356 Z" fill="#fef3c7" stroke="#f0d878" stroke-width="0.5"/><path d="M0,318 L285,318" stroke="#e1e4e8" stroke-width="1"/>
-<path d="M142.5,318 L285,318 L285,356 A4,4 0 0 1 281,360 L142.5,360 Z" fill="#f3f5f7"/><path d="M142.5,318 L142.5,360" stroke="#e1e4e8" stroke-width="1"/>
-<text x="18" y="335" class="small">codec @ max</text>
-<text x="18" y="351" class="score" fill="#1a1a1a">61.8</text>
-<text x="160.5" y="335" class="small">frame @ max</text>
-<text x="160.5" y="351" class="score" fill="#4a5258">42.8</text>
+<g id="cvf-panel-5" transform="translate(258.00,256.00)" style="animation-delay:0.40s">
+<text x="48" y="99" class="panel-title">VideoEval-Pro</text>
+<text x="48" y="111" class="subhead">peak +3.4  ·  8f Δ +3.1  ·  128f Δ +1.5</text>
+
+<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid" />
+<text x="42" y="297.0" text-anchor="end" class="tick">42</text>
+
+<line x1="48" y1="204.0" x2="238" y2="204.0" class="grid" />
+<text x="42" y="207.0" text-anchor="end" class="tick">50</text>
+
+<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid" />
+<text x="42" y="117.0" text-anchor="end" class="tick">58</text>
+<text x="48.0" y="316.0" text-anchor="middle" class="tick">8</text>
+<text x="95.5" y="316.0" text-anchor="middle" class="tick">16</text>
+<text x="190.5" y="316.0" text-anchor="middle" class="tick">64</text>
+<text x="238.0" y="316.0" text-anchor="middle" class="tick">128</text>
+<line class="grid" x1="48.0" y1="114" x2="48.0" y2="294" /><line class="grid" x1="95.5" y1="114" x2="95.5" y2="294" /><line class="grid" x1="190.5" y1="114" x2="190.5" y2="294" /><line class="grid" x1="238.0" y1="114" x2="238.0" y2="294" /><polygon points="48.0,281.6 95.5,262.5 143.0,219.8 190.5,178.1 238.0,159.0 238.0,142.1 190.5,162.4 143.0,188.2 95.5,224.2 48.0,246.7" fill="#fef3c7" opacity="0.4" />
+
+<line x1="48" y1="114" x2="48" y2="294" class="axis" />
+
+<line x1="48" y1="294" x2="238" y2="294" class="axis" />
+<polyline points="48.0,281.6 95.5,262.5 143.0,219.8 190.5,178.1 238.0,159.0" fill="none" stroke="#8c959f" stroke-width="1.3" stroke-dasharray="3 2" />
+<polyline class="codec-line" points="48.0,246.7 95.5,224.2 143.0,188.2 190.5,162.4 238.0,142.1" fill="none" stroke="#1a1a1a" stroke-width="1.8" />
+<text x="244" y="146.1" class="score-codec">55.5</text>
+<text x="244" y="163.0" class="score-frame">54.0</text>
 </g>
-<line x1="46.26" y1="936" x2="1243.17" y2="936" stroke="#1a1a1a" stroke-width="0.45"/>
-<text x="46.26" y="958" class="note">Each panel reports codec minus frame (Δ) at the smallest and largest tested budgets; pale cells mark codec-leading regions.</text>
+<g id="cvf-panel-6" transform="translate(528.00,256.00)" style="animation-delay:0.48s">
+<text x="48" y="99" class="panel-title">OV-Rope</text>
+<text x="48" y="111" class="subhead">peak +21.4  ·  16f Δ +2.8  ·  128f Δ +19.0</text>
+
+<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid" />
+<text x="42" y="297.0" text-anchor="end" class="tick">35</text>
+
+<line x1="48" y1="234.0" x2="238" y2="234.0" class="grid" />
+<text x="42" y="237.0" text-anchor="end" class="tick">45</text>
+
+<line x1="48" y1="174.0" x2="238" y2="174.0" class="grid" />
+<text x="42" y="177.0" text-anchor="end" class="tick">55</text>
+
+<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid" />
+<text x="42" y="117.0" text-anchor="end" class="tick">65</text>
+<text x="48.0" y="316.0" text-anchor="middle" class="tick">16</text>
+<text x="174.7" y="316.0" text-anchor="middle" class="tick">64</text>
+<text x="238.0" y="316.0" text-anchor="middle" class="tick">128</text>
+<line class="grid" x1="48.0" y1="114" x2="48.0" y2="294" /><line class="grid" x1="174.7" y1="114" x2="174.7" y2="294" /><line class="grid" x1="238.0" y1="114" x2="238.0" y2="294" /><polygon points="48.0,279.6 111.3,286.8 174.7,277.8 238.0,247.2 238.0,133.2 174.7,149.4 111.3,202.2 48.0,262.8" fill="#fef3c7" opacity="0.4" />
+
+<line x1="48" y1="114" x2="48" y2="294" class="axis" />
+
+<line x1="48" y1="294" x2="238" y2="294" class="axis" />
+<polyline points="48.0,279.6 111.3,286.8 174.7,277.8 238.0,247.2" fill="none" stroke="#8c959f" stroke-width="1.3" stroke-dasharray="3 2" />
+<polyline class="codec-line" points="48.0,262.8 111.3,202.2 174.7,149.4 238.0,133.2" fill="none" stroke="#1a1a1a" stroke-width="1.8" />
+<text x="244" y="137.2" class="score-codec">61.8</text>
+<text x="244" y="251.2" class="score-frame">42.8</text>
+</g>
+<g id="cvf-panel-7" transform="translate(798.00,256.00)" style="animation-delay:0.56s">
+<text x="48" y="99" class="panel-title">Overall Averages</text>
+<text x="48" y="140" class="subhead" fill="#1a1a1a">Average Peak Δ</text>
+<text x="210" y="140" class="score-codec" fill="#1a1a1a">+14.1</text>
+<text x="48" y="170" class="subhead" fill="#1a1a1a">Codec @ Max (Avg)</text>
+<text x="210" y="170" class="score-codec" fill="#1a1a1a">57.0</text>
+<text x="48" y="200" class="subhead" fill="#1a1a1a">Frame @ Max (Avg)</text>
+<text x="210" y="200" class="score-frame">53.0</text>
+<text x="48" y="250" class="subhead" fill="#6a737d">Codec sampling consistently</text>
+<text x="48" y="270" class="subhead" fill="#6a737d">extends temporal coverage and</text>
+<text x="48" y="290" class="subhead" fill="#6a737d">peak performance overall.</text>
+</g>
 </svg>

--- a/asset/method_unified_encoder.svg
+++ b/asset/method_unified_encoder.svg
@@ -242,7 +242,7 @@
   <g>
     <rect x="60" y="602" width="3" height="162" rx="1.5" fill="#0d9488"/>
     <text x="74" y="626" class="panel-title">Codec-Aligned</text>
-    <text x="74" y="648" class="panel-sub">24 frames · I-frame patches + P-frame motion patches</text>
+    <text x="74" y="648" class="panel-sub">32 frames · I-frame patches + P-frame motion patches</text>
     <text x="1020" y="628" text-anchor="end" class="stat-num" fill="#0d9488">32</text>
     <text x="1020" y="646" text-anchor="end" class="stat-label">tokens</text>
     <rect x="138" y="672" width="23" height="23" rx="2" fill="#f59e0b" opacity="0.9"/>
@@ -298,34 +298,34 @@
     <text x="176.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">0</text>
     <text x="203.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">0</text>
     <text x="230.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">0</text>
-    <text x="257.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">0</text>
-    <text x="284.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">0</text>
-    <text x="311.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">0</text>
-    <text x="338.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">0</text>
-    <text x="365.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">1</text>
-    <text x="392.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">1</text>
-    <text x="419.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">1</text>
-    <text x="446.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">1</text>
-    <text x="473.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">1</text>
-    <text x="500.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">1</text>
-    <text x="527.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">1</text>
-    <text x="554.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">1</text>
-    <text x="581.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">2</text>
-    <text x="608.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">2</text>
-    <text x="635.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">2</text>
-    <text x="662.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">2</text>
-    <text x="689.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">2</text>
-    <text x="716.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">2</text>
-    <text x="743.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">2</text>
-    <text x="770.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">2</text>
-    <text x="797.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">3</text>
-    <text x="824.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">3</text>
-    <text x="851.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">3</text>
-    <text x="878.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">3</text>
-    <text x="905.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">3</text>
-    <text x="932.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">3</text>
-    <text x="959.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">3</text>
-    <text x="986.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">3</text>
+    <text x="257.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">2</text>
+    <text x="284.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">4</text>
+    <text x="311.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">6</text>
+    <text x="338.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">8</text>
+    <text x="365.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">8</text>
+    <text x="392.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">8</text>
+    <text x="419.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">8</text>
+    <text x="446.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">8</text>
+    <text x="473.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">10</text>
+    <text x="500.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">12</text>
+    <text x="527.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">14</text>
+    <text x="554.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">16</text>
+    <text x="581.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">16</text>
+    <text x="608.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">16</text>
+    <text x="635.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">16</text>
+    <text x="662.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">16</text>
+    <text x="689.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">18</text>
+    <text x="716.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">20</text>
+    <text x="743.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">22</text>
+    <text x="770.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">24</text>
+    <text x="797.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">24</text>
+    <text x="824.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">24</text>
+    <text x="851.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">24</text>
+    <text x="878.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">24</text>
+    <text x="905.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">26</text>
+    <text x="932.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">28</text>
+    <text x="959.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">30</text>
+    <text x="986.5" y="717" text-anchor="middle" class="pos-num" fill="#9a3412">32</text>
     <text x="74" y="733" class="pos-label" fill="#15803d">h:</text>
     <text x="149.5" y="733" text-anchor="middle" class="pos-num" fill="#15803d">0</text>
     <text x="176.5" y="733" text-anchor="middle" class="pos-num" fill="#15803d">0</text>


### PR DESCRIPTION
This pull request makes a minor documentation improvement to the `README.md` file by clarifying the image alt text for Figure 4 and removing an unnecessary details/summary block. No code or functionality is affected.

- Documentation update:
  * Improved the alt text for the Figure 4 image to clearly describe it as "Figure 4: codec-aligned sampling compared with uniform frame sampling across video benchmarks" and removed the redundant details/summary HTML block.