### PR TITLE
docs: switch method figures to dual light/dark SVG files for mobile compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,11 @@ And unlike most "open" releases, *everything* ships alongside them: encoder weig
 </p>
 
 <p align="center">
-  <img src="asset/method_codec_vs_frame.svg" width="100%" alt="Figure 4: codec-aligned sampling compared with uniform frame sampling across video benchmarks">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="asset/method_codec_vs_frame_dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="asset/method_codec_vs_frame_light.svg">
+    <img src="asset/method_codec_vs_frame_light.svg" width="100%" alt="Figure 4: codec-aligned sampling compared with uniform frame sampling across video benchmarks">
+  </picture>
 </p>
 
 
@@ -90,7 +94,11 @@ And unlike most "open" releases, *everything* ships alongside them: encoder weig
 ### Codec-Style Patch Selection
 
 <p align="left">
-  <img src="asset/method_codec_selection.svg" alt="Codec-Style Patch Selection: same 54-token budget, 3× more temporal range than uniform sampling" width="88%">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="asset/method_codec_selection_dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="asset/method_codec_selection_light.svg">
+    <img src="asset/method_codec_selection_light.svg" alt="Codec-Style Patch Selection: same 54-token budget, 3× more temporal range than uniform sampling" width="88%">
+  </picture>
 </p>
 
 Standard video pipelines uniformly sample a handful of frames and process **every** patch — most of it static background. We borrow from HEVC: keep **I-frames** dense, keep only **motion- and residual-rich patches** from **P-frames**. Same 54-token budget, **18 frames** instead of 6 — 3× the temporal range, no extra LLM context, no input-type adapters.
@@ -98,7 +106,11 @@ Standard video pipelines uniformly sample a handful of frames and process **ever
 ### One Encoder, Every Modality
 
 <p align="left">
-  <img src="asset/method_unified_encoder.svg" alt="Multi-modal vision input: image, uniform frames, or codec-aligned tokens all feed the same OneVision-Encoder with shared (t, h, w) positions" width="66%">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="asset/method_unified_encoder_dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="asset/method_unified_encoder_light.svg">
+    <img src="asset/method_unified_encoder_light.svg" alt="Multi-modal vision input: image, uniform frames, or codec-aligned tokens all feed the same OneVision-Encoder with shared (t, h, w) positions" width="66%">
+  </picture>
 </p>
 
 Most multimodal stacks ship a different tokenizer per input type — one path for images, another for video, a third for multi-image. We don't. **Image, uniform frames, and codec-aligned tokens** all flow into the **same OneVision-Encoder** under a shared `(t, h, w)` position scheme. No task-specific tokenizers, no per-modality routing.

--- a/asset/method_codec_selection_dark.svg
+++ b/asset/method_codec_selection_dark.svg
@@ -1,51 +1,29 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 526" font-family="-apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif">
   <defs>
     <style><![CDATA[
-.title { font-size: 28px; font-weight: 700; fill: #0f172a; }
-      .subtitle { font-size: 14px; font-weight: 500; fill: #64748b; letter-spacing: 0.04em; text-transform: uppercase; }
-      .panel-title { font-size: 19px; font-weight: 600; fill: #0f172a; }
-      .panel-sub { font-size: 13px; font-weight: 400; fill: #64748b; }
-      .stat-num { font-size: 36px; font-weight: 700; fill: #0f172a; }
-      .stat-num-accent { font-size: 36px; font-weight: 700; fill: #2563eb; }
-      .stat-label { font-size: 11px; font-weight: 500; fill: #64748b; letter-spacing: 0.05em; text-transform: uppercase; }
-      .frame-label { font-size: 10px; font-weight: 600; fill: #475569; }
-      .legend-text { font-size: 12px; font-weight: 500; fill: #334155; }
-      .formula { font-size: 12px; font-weight: 500; fill: #475569; font-family: 'SF Mono', 'Menlo', 'Consolas', monospace; }
-      .divider { stroke: #e2e8f0; stroke-width: 1; }
-      .frame-border { fill: none; stroke: #cbd5e1; stroke-width: 1.5; }
-      .iframe-border { fill: none; stroke: #2563eb; stroke-width: 2; }
-      .pframe-border { fill: none; stroke: #94a3b8; stroke-width: 1; stroke-dasharray: 3 2; }
+.title { font-size: 28px; font-weight: 700; fill: #f0f6fc; }
+      .subtitle { font-size: 14px; font-weight: 500; fill: #8b949e; letter-spacing: 0.04em; text-transform: uppercase; }
+      .panel-title { font-size: 19px; font-weight: 600; fill: #f0f6fc; }
+      .panel-sub { font-size: 13px; font-weight: 400; fill: #8b949e; }
+      .stat-num { font-size: 36px; font-weight: 700; fill: #f0f6fc; }
+      .stat-num-accent { font-size: 36px; font-weight: 700; fill: #58a6ff; }
+      .stat-label { font-size: 11px; font-weight: 500; fill: #8b949e; letter-spacing: 0.05em; text-transform: uppercase; }
+      .frame-label { font-size: 10px; font-weight: 600; fill: #8b949e; }
+      .legend-text { font-size: 12px; font-weight: 500; fill: #b8c0c8; }
+      .formula { font-size: 12px; font-weight: 500; fill: #8b949e; font-family: 'SF Mono', 'Menlo', 'Consolas', monospace; }
+      .divider { stroke: #30363d; stroke-width: 1; }
+      .frame-border { fill: none; stroke: #484f58; stroke-width: 1.5; }
+      .iframe-border { fill: none; stroke: #58a6ff; stroke-width: 2; }
+      .pframe-border { fill: none; stroke: #6e7681; stroke-width: 1; stroke-dasharray: 3 2; }
 
     /* Extracted Inline Colors */
-    .fill-ffffff { fill: #ffffff; }
-    .fill-2563eb { fill: #2563eb; }
+    .fill-ffffff { fill: #0d1117; }
+    .fill-2563eb { fill: #58a6ff; }
     .fill-f59e0b { fill: #f59e0b; }
     .fill-3b82f6 { fill: #3b82f6; }
-    .stroke-94a3b8 { stroke: #94a3b8; }
-    .fill-94a3b8 { fill: #94a3b8; }
-    .fill-64748b { fill: #64748b; }
-
-    @media (prefers-color-scheme: dark) {
-      .title { fill: #f0f6fc; }
-      .subtitle { fill: #8b949e; }
-      .panel-title { fill: #f0f6fc; }
-      .panel-sub { fill: #8b949e; }
-      .stat-num { fill: #f0f6fc; }
-      .stat-num-accent { fill: #58a6ff; }
-      .stat-label { fill: #8b949e; }
-      .frame-label { fill: #8b949e; }
-      .legend-text { fill: #b8c0c8; }
-      .formula { fill: #8b949e; }
-      .divider { stroke: #30363d; }
-      .frame-border { stroke: #484f58; }
-      .iframe-border { stroke: #58a6ff; }
-      .pframe-border { stroke: #6e7681; }
-      .fill-ffffff { fill: #0d1117; }
-      .fill-2563eb { fill: #58a6ff; }
-      .stroke-94a3b8 { stroke: #6e7681; }
-      .fill-94a3b8 { fill: #6e7681; }
-      .fill-64748b { fill: #8b949e; }
-    }
+    .stroke-94a3b8 { stroke: #6e7681; }
+    .fill-94a3b8 { fill: #6e7681; }
+    .fill-64748b { fill: #8b949e; }
   ]]></style>
   </defs>
 

--- a/asset/method_codec_selection_light.svg
+++ b/asset/method_codec_selection_light.svg
@@ -1,0 +1,133 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 526" font-family="-apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif">
+  <defs>
+    <style><![CDATA[
+.title { font-size: 28px; font-weight: 700; fill: #0f172a; }
+      .subtitle { font-size: 14px; font-weight: 500; fill: #64748b; letter-spacing: 0.04em; text-transform: uppercase; }
+      .panel-title { font-size: 19px; font-weight: 600; fill: #0f172a; }
+      .panel-sub { font-size: 13px; font-weight: 400; fill: #64748b; }
+      .stat-num { font-size: 36px; font-weight: 700; fill: #0f172a; }
+      .stat-num-accent { font-size: 36px; font-weight: 700; fill: #2563eb; }
+      .stat-label { font-size: 11px; font-weight: 500; fill: #64748b; letter-spacing: 0.05em; text-transform: uppercase; }
+      .frame-label { font-size: 10px; font-weight: 600; fill: #475569; }
+      .legend-text { font-size: 12px; font-weight: 500; fill: #334155; }
+      .formula { font-size: 12px; font-weight: 500; fill: #475569; font-family: 'SF Mono', 'Menlo', 'Consolas', monospace; }
+      .divider { stroke: #e2e8f0; stroke-width: 1; }
+      .frame-border { fill: none; stroke: #cbd5e1; stroke-width: 1.5; }
+      .iframe-border { fill: none; stroke: #2563eb; stroke-width: 2; }
+      .pframe-border { fill: none; stroke: #94a3b8; stroke-width: 1; stroke-dasharray: 3 2; }
+
+    /* Extracted Inline Colors */
+    .fill-ffffff { fill: #ffffff; }
+    .fill-2563eb { fill: #2563eb; }
+    .fill-f59e0b { fill: #f59e0b; }
+    .fill-3b82f6 { fill: #3b82f6; }
+    .stroke-94a3b8 { stroke: #94a3b8; }
+    .fill-94a3b8 { fill: #94a3b8; }
+    .fill-64748b { fill: #64748b; }
+  ]]></style>
+  </defs>
+
+  
+  <rect width="1080" height="526" class="fill-ffffff" />
+
+  
+  <text x="60" y="60" class="subtitle">Figure 1 · Codec-Style Patch Selection</text>
+  <text x="60" y="98" class="title">Same 54-token budget. 3× the temporal range.</text>
+  <text x="60" y="128" class="panel-sub">Standard pipelines spend their budget on a few dense frames. We keep <tspan font-weight="700" class="fill-2563eb">I-frames dense</tspan> and skim <tspan font-weight="700" class="fill-f59e0b">motion-rich patches</tspan> from P-frames instead.</text>
+
+  <line x1="60" y1="144" x2="1020" y2="144" class="divider" />
+
+  
+  <g transform="translate(60, 178)">
+    <text x="0" y="0" class="panel-title">Uniform Sampling</text>
+    <text x="0" y="22" class="panel-sub">Every frame, every patch — dense but shallow in time.</text>
+
+    <g transform="translate(0, 50)">
+            <g transform="translate(0,0)"><rect width="64" height="64" class="frame-border" rx="2" /><g opacity="0.85" class="fill-3b82f6"><rect x="4" y="4" width="17" height="17" rx="1" /><rect x="23" y="4" width="17" height="17" rx="1" /><rect x="42" y="4" width="17" height="17" rx="1" /><rect x="4" y="23" width="17" height="17" rx="1" /><rect x="23" y="23" width="17" height="17" rx="1" /><rect x="42" y="23" width="17" height="17" rx="1" /><rect x="4" y="42" width="17" height="17" rx="1" /><rect x="23" y="42" width="17" height="17" rx="1" /><rect x="42" y="42" width="17" height="17" rx="1" /></g><text x="32" y="80" text-anchor="middle" class="frame-label">f₁</text></g>
+      <g transform="translate(76,0)"><rect width="64" height="64" class="frame-border" rx="2" /><g opacity="0.85" class="fill-3b82f6"><rect x="4" y="4" width="17" height="17" rx="1" /><rect x="23" y="4" width="17" height="17" rx="1" /><rect x="42" y="4" width="17" height="17" rx="1" /><rect x="4" y="23" width="17" height="17" rx="1" /><rect x="23" y="23" width="17" height="17" rx="1" /><rect x="42" y="23" width="17" height="17" rx="1" /><rect x="4" y="42" width="17" height="17" rx="1" /><rect x="23" y="42" width="17" height="17" rx="1" /><rect x="42" y="42" width="17" height="17" rx="1" /></g><text x="32" y="80" text-anchor="middle" class="frame-label">f₂</text></g>
+      <g transform="translate(152,0)"><rect width="64" height="64" class="frame-border" rx="2" /><g opacity="0.85" class="fill-3b82f6"><rect x="4" y="4" width="17" height="17" rx="1" /><rect x="23" y="4" width="17" height="17" rx="1" /><rect x="42" y="4" width="17" height="17" rx="1" /><rect x="4" y="23" width="17" height="17" rx="1" /><rect x="23" y="23" width="17" height="17" rx="1" /><rect x="42" y="23" width="17" height="17" rx="1" /><rect x="4" y="42" width="17" height="17" rx="1" /><rect x="23" y="42" width="17" height="17" rx="1" /><rect x="42" y="42" width="17" height="17" rx="1" /></g><text x="32" y="80" text-anchor="middle" class="frame-label">f₃</text></g>
+      <g transform="translate(228,0)"><rect width="64" height="64" class="frame-border" rx="2" /><g opacity="0.85" class="fill-3b82f6"><rect x="4" y="4" width="17" height="17" rx="1" /><rect x="23" y="4" width="17" height="17" rx="1" /><rect x="42" y="4" width="17" height="17" rx="1" /><rect x="4" y="23" width="17" height="17" rx="1" /><rect x="23" y="23" width="17" height="17" rx="1" /><rect x="42" y="23" width="17" height="17" rx="1" /><rect x="4" y="42" width="17" height="17" rx="1" /><rect x="23" y="42" width="17" height="17" rx="1" /><rect x="42" y="42" width="17" height="17" rx="1" /></g><text x="32" y="80" text-anchor="middle" class="frame-label">f₄</text></g>
+      <g transform="translate(304,0)"><rect width="64" height="64" class="frame-border" rx="2" /><g opacity="0.85" class="fill-3b82f6"><rect x="4" y="4" width="17" height="17" rx="1" /><rect x="23" y="4" width="17" height="17" rx="1" /><rect x="42" y="4" width="17" height="17" rx="1" /><rect x="4" y="23" width="17" height="17" rx="1" /><rect x="23" y="23" width="17" height="17" rx="1" /><rect x="42" y="23" width="17" height="17" rx="1" /><rect x="4" y="42" width="17" height="17" rx="1" /><rect x="23" y="42" width="17" height="17" rx="1" /><rect x="42" y="42" width="17" height="17" rx="1" /></g><text x="32" y="80" text-anchor="middle" class="frame-label">f₅</text></g>
+      <g transform="translate(380,0)"><rect width="64" height="64" class="frame-border" rx="2" /><g opacity="0.85" class="fill-3b82f6"><rect x="4" y="4" width="17" height="17" rx="1" /><rect x="23" y="4" width="17" height="17" rx="1" /><rect x="42" y="4" width="17" height="17" rx="1" /><rect x="4" y="23" width="17" height="17" rx="1" /><rect x="23" y="23" width="17" height="17" rx="1" /><rect x="42" y="23" width="17" height="17" rx="1" /><rect x="4" y="42" width="17" height="17" rx="1" /><rect x="23" y="42" width="17" height="17" rx="1" /><rect x="42" y="42" width="17" height="17" rx="1" /></g><text x="32" y="80" text-anchor="middle" class="frame-label">f₆</text></g>
+
+      
+      <g transform="translate(0, 92)">
+        <line x1="0" y1="0" x2="444" y2="0" stroke-width="1.5" class="stroke-94a3b8" />
+        <polygon points="444,0 438,-4 438,4" class="fill-94a3b8" />
+        <text x="222.0" y="20" text-anchor="middle" class="frame-label fill-64748b">time · 6 frames</text>
+      </g>
+
+      
+      <g transform="translate(0, 150)">
+        <text x="0" y="0" class="stat-num">54</text>
+        <text x="0" y="20" class="stat-label">tokens</text>
+        <text x="120" y="0" class="stat-num">6</text>
+        <text x="120" y="20" class="stat-label">frames</text>
+        <text x="220" y="0" class="stat-num">9</text>
+        <text x="220" y="20" class="stat-label">patches / frame</text>
+      </g>
+    </g>
+  </g>
+
+  
+  <line x1="540" y1="178" x2="540" y2="446" class="divider" />
+
+  
+  <g transform="translate(580, 178)">
+    <text x="0" y="0" class="panel-title">Codec-Aligned Selection</text>
+    <text x="0" y="22" class="panel-sub">I-frames dense; P-frames keep only motion-rich patches.</text>
+
+    <g transform="translate(0, 50)">
+            
+      <g transform="translate(0,0)"><rect width="22" height="64" class="iframe-border" rx="2" /><g opacity="0.9" class="fill-2563eb"><rect x="2" y="3" width="5.5" height="18" rx="0.5" /><rect x="8.25" y="3" width="5.5" height="18" rx="0.5" /><rect x="14.5" y="3" width="5.5" height="18" rx="0.5" /><rect x="2" y="23" width="5.5" height="18" rx="0.5" /><rect x="8.25" y="23" width="5.5" height="18" rx="0.5" /><rect x="14.5" y="23" width="5.5" height="18" rx="0.5" /><rect x="2" y="43" width="5.5" height="18" rx="0.5" /><rect x="8.25" y="43" width="5.5" height="18" rx="0.5" /><rect x="14.5" y="43" width="5.5" height="18" rx="0.5" /></g><text x="11" y="80" text-anchor="middle" class="frame-label fill-2563eb" font-weight="700">I</text></g>
+      <g transform="translate(25,0)"><rect width="22" height="64" class="pframe-border" rx="2" /><rect x="2" y="15.5" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><rect x="14.5" y="34.25" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><text x="11" y="80" text-anchor="middle" class="frame-label">P</text></g>
+      <g transform="translate(50,0)"><rect width="22" height="64" class="pframe-border" rx="2" /><rect x="8.25" y="9.25" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><text x="11" y="80" text-anchor="middle" class="frame-label">P</text></g>
+      <g transform="translate(75,0)"><rect width="22" height="64" class="pframe-border" rx="2" /><rect x="14.5" y="21.75" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><rect x="2" y="40.5" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><text x="11" y="80" text-anchor="middle" class="frame-label">P</text></g>
+      <g transform="translate(100,0)"><rect width="22" height="64" class="pframe-border" rx="2" /><rect x="8.25" y="28" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><text x="11" y="80" text-anchor="middle" class="frame-label">P</text></g>
+      <g transform="translate(125,0)"><rect width="22" height="64" class="pframe-border" rx="2" /><rect x="2" y="28" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><rect x="14.5" y="9.25" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><rect x="8.25" y="46.75" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><text x="11" y="80" text-anchor="middle" class="frame-label">P</text></g>
+      
+      <g transform="translate(150,0)"><rect width="22" height="64" class="iframe-border" rx="2" /><g opacity="0.9" class="fill-2563eb"><rect x="2" y="3" width="5.5" height="18" rx="0.5" /><rect x="8.25" y="3" width="5.5" height="18" rx="0.5" /><rect x="14.5" y="3" width="5.5" height="18" rx="0.5" /><rect x="2" y="23" width="5.5" height="18" rx="0.5" /><rect x="8.25" y="23" width="5.5" height="18" rx="0.5" /><rect x="14.5" y="23" width="5.5" height="18" rx="0.5" /><rect x="2" y="43" width="5.5" height="18" rx="0.5" /><rect x="8.25" y="43" width="5.5" height="18" rx="0.5" /><rect x="14.5" y="43" width="5.5" height="18" rx="0.5" /></g><text x="11" y="80" text-anchor="middle" class="frame-label fill-2563eb" font-weight="700">I</text></g>
+      <g transform="translate(175,0)"><rect width="22" height="64" class="pframe-border" rx="2" /><rect x="2" y="15.5" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><rect x="14.5" y="34.25" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><text x="11" y="80" text-anchor="middle" class="frame-label">P</text></g>
+      <g transform="translate(200,0)"><rect width="22" height="64" class="pframe-border" rx="2" /><rect x="8.25" y="9.25" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><text x="11" y="80" text-anchor="middle" class="frame-label">P</text></g>
+      <g transform="translate(225,0)"><rect width="22" height="64" class="pframe-border" rx="2" /><rect x="14.5" y="21.75" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><rect x="2" y="40.5" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><text x="11" y="80" text-anchor="middle" class="frame-label">P</text></g>
+      <g transform="translate(250,0)"><rect width="22" height="64" class="pframe-border" rx="2" /><rect x="8.25" y="28" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><text x="11" y="80" text-anchor="middle" class="frame-label">P</text></g>
+      <g transform="translate(275,0)"><rect width="22" height="64" class="pframe-border" rx="2" /><rect x="2" y="28" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><rect x="14.5" y="9.25" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><rect x="8.25" y="46.75" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><text x="11" y="80" text-anchor="middle" class="frame-label">P</text></g>
+      
+      <g transform="translate(300,0)"><rect width="22" height="64" class="iframe-border" rx="2" /><g opacity="0.9" class="fill-2563eb"><rect x="2" y="3" width="5.5" height="18" rx="0.5" /><rect x="8.25" y="3" width="5.5" height="18" rx="0.5" /><rect x="14.5" y="3" width="5.5" height="18" rx="0.5" /><rect x="2" y="23" width="5.5" height="18" rx="0.5" /><rect x="8.25" y="23" width="5.5" height="18" rx="0.5" /><rect x="14.5" y="23" width="5.5" height="18" rx="0.5" /><rect x="2" y="43" width="5.5" height="18" rx="0.5" /><rect x="8.25" y="43" width="5.5" height="18" rx="0.5" /><rect x="14.5" y="43" width="5.5" height="18" rx="0.5" /></g><text x="11" y="80" text-anchor="middle" class="frame-label fill-2563eb" font-weight="700">I</text></g>
+      <g transform="translate(325,0)"><rect width="22" height="64" class="pframe-border" rx="2" /><rect x="2" y="15.5" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><rect x="14.5" y="34.25" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><text x="11" y="80" text-anchor="middle" class="frame-label">P</text></g>
+      <g transform="translate(350,0)"><rect width="22" height="64" class="pframe-border" rx="2" /><rect x="8.25" y="9.25" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><text x="11" y="80" text-anchor="middle" class="frame-label">P</text></g>
+      <g transform="translate(375,0)"><rect width="22" height="64" class="pframe-border" rx="2" /><rect x="14.5" y="21.75" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><rect x="2" y="40.5" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><text x="11" y="80" text-anchor="middle" class="frame-label">P</text></g>
+      <g transform="translate(400,0)"><rect width="22" height="64" class="pframe-border" rx="2" /><rect x="8.25" y="28" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><text x="11" y="80" text-anchor="middle" class="frame-label">P</text></g>
+      <g transform="translate(425,0)"><rect width="22" height="64" class="pframe-border" rx="2" /><rect x="2" y="28" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><rect x="14.5" y="9.25" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><rect x="8.25" y="46.75" width="5.5" height="5.5" opacity="0.9" class="fill-f59e0b" /><text x="11" y="80" text-anchor="middle" class="frame-label">P</text></g>
+
+      
+      <g transform="translate(0, 92)">
+        <line x1="0" y1="0" x2="447" y2="0" stroke-width="1.5" class="stroke-94a3b8" />
+        <polygon points="447,0 441,-4 441,4" class="fill-94a3b8" />
+        <text x="223.5" y="20" text-anchor="middle" class="frame-label fill-64748b">time · 18 frames (3× longer)</text>
+      </g>
+
+      
+      <g transform="translate(0, 150)">
+        <text x="0" y="0" class="stat-num">54</text>
+        <text x="0" y="20" class="stat-label">tokens</text>
+        <text x="120" y="0" class="stat-num-accent">18</text>
+        <text x="120" y="20" class="stat-label">frames</text>
+        <text x="220" y="0" class="stat-num-accent">3×</text>
+        <text x="220" y="20" class="stat-label">temporal range</text>
+      </g>
+    </g>
+  </g>
+
+  
+  <g transform="translate(60, 494)">
+    <rect x="0" y="-11" width="14" height="14" opacity="0.9" class="fill-2563eb" />
+    <text x="22" y="0" class="legend-text">I-frame patch (dense, all kept)</text>
+
+    <rect x="240" y="-11" width="14" height="14" opacity="0.9" class="fill-f59e0b" />
+    <text x="262" y="0" class="legend-text">P-frame patch (motion-rich)</text>
+
+    <rect x="540" y="-11" width="14" height="14" fill="none" stroke-width="1" stroke-dasharray="3 2" class="stroke-94a3b8" />
+    <text x="562" y="0" class="legend-text">P-frame (most patches dropped)</text>
+  </g>
+</svg>

--- a/asset/method_codec_vs_frame_dark.svg
+++ b/asset/method_codec_vs_frame_dark.svg
@@ -7,43 +7,24 @@
 @keyframes cvf-draw{from{stroke-dashoffset:900}to{stroke-dashoffset:0}}
 g[id^="cvf-panel-"]{animation:cvf-fade .4s ease-out both}
 .codec-line{stroke-dasharray:900;animation:cvf-draw 1.2s ease-out .35s both}
-.caption{font:600 15px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#1a1a1a}
-.caption-muted{fill:#6a737d}
-.panel-title{font:600 14px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#1a1a1a}
-.subhead{font:12px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#6a737d}
-.tick{font:12px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#6a737d}
-.score-codec{font:bold 13px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#1a1a1a}
-.score-frame{font:bold 13px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#6a737d}
-.axis{stroke:#1a1a1a;stroke-width:0.6}
-.grid{stroke:#eaecef;stroke-width:0.8}
+.caption{font:600 15px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#f0f6fc}
+.caption-muted{fill:#8b949e}
+.panel-title{font:600 14px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#f0f6fc}
+.subhead{font:12px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#8b949e}
+.tick{font:12px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#8b949e}
+.score-codec{font:bold 13px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#f0f6fc}
+.score-frame{font:bold 13px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#8b949e}
+.axis{stroke:#f0f6fc;stroke-width:0.6}
+.grid{stroke:#30363d;stroke-width:0.8}
 
     /* Extracted Inline Colors */
-    .fill-ffffff { fill: #ffffff; }
-    .stroke-eaecef { stroke: #eaecef; }
-    .stroke-1a1a1a { stroke: #1a1a1a; }
-    .stroke-8c959f { stroke: #8c959f; }
-    .fill-fef3c7 { fill: #fef3c7; }
-    .fill-1a1a1a { fill: #1a1a1a; }
-    .fill-6a737d { fill: #6a737d; }
-
-    @media (prefers-color-scheme: dark) {
-      .caption { fill: #f0f6fc; }
-      .caption-muted { fill: #8b949e; }
-      .panel-title { fill: #f0f6fc; }
-      .subhead { fill: #8b949e; }
-      .tick { fill: #8b949e; }
-      .score-codec { fill: #f0f6fc; }
-      .score-frame { fill: #8b949e; }
-      .axis { stroke: #f0f6fc; }
-      .grid { stroke: #30363d; }
-      .fill-ffffff { fill: #0d1117; }
-      .stroke-eaecef { stroke: #30363d; }
-      .stroke-1a1a1a { stroke: #f0f6fc; }
-      .stroke-8c959f { stroke: #6e7681; }
-      .fill-fef3c7 { fill: #3d2f08; }
-      .fill-1a1a1a { fill: #f0f6fc; }
-      .fill-6a737d { fill: #8b949e; }
-    }
+    .fill-ffffff { fill: #0d1117; }
+    .stroke-eaecef { stroke: #30363d; }
+    .stroke-1a1a1a { stroke: #f0f6fc; }
+    .stroke-8c959f { stroke: #6e7681; }
+    .fill-fef3c7 { fill: #3d2f08; }
+    .fill-1a1a1a { fill: #f0f6fc; }
+    .fill-6a737d { fill: #8b949e; }
   ]]></style>
 </defs>
 <rect width="1100" height="580" class="fill-ffffff" />

--- a/asset/method_codec_vs_frame_light.svg
+++ b/asset/method_codec_vs_frame_light.svg
@@ -1,0 +1,241 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="580" viewBox="0 0 1100 580" role="img" aria-labelledby="title desc">
+<title id="title">Codec vs Frame Sampling</title>
+<desc id="desc">Table-style small multiples comparing codec-aligned sampling against uniform frame sampling across seven video benchmarks.</desc>
+<defs>
+<style><![CDATA[
+@keyframes cvf-fade{from{opacity:0}to{opacity:1}}
+@keyframes cvf-draw{from{stroke-dashoffset:900}to{stroke-dashoffset:0}}
+g[id^="cvf-panel-"]{animation:cvf-fade .4s ease-out both}
+.codec-line{stroke-dasharray:900;animation:cvf-draw 1.2s ease-out .35s both}
+.caption{font:600 15px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#1a1a1a}
+.caption-muted{fill:#6a737d}
+.panel-title{font:600 14px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#1a1a1a}
+.subhead{font:12px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#6a737d}
+.tick{font:12px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#6a737d}
+.score-codec{font:bold 13px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#1a1a1a}
+.score-frame{font:bold 13px "DejaVu Serif", "Nimbus Roman", "Times New Roman", "Times", serif;fill:#6a737d}
+.axis{stroke:#1a1a1a;stroke-width:0.6}
+.grid{stroke:#eaecef;stroke-width:0.8}
+
+    /* Extracted Inline Colors */
+    .fill-ffffff { fill: #ffffff; }
+    .stroke-eaecef { stroke: #eaecef; }
+    .stroke-1a1a1a { stroke: #1a1a1a; }
+    .stroke-8c959f { stroke: #8c959f; }
+    .fill-fef3c7 { fill: #fef3c7; }
+    .fill-1a1a1a { fill: #1a1a1a; }
+    .fill-6a737d { fill: #6a737d; }
+  ]]></style>
+</defs>
+<rect width="1100" height="580" class="fill-ffffff" />
+
+<line x1="36" y1="323" x2="1036" y2="323" stroke-width="0.6" class="stroke-eaecef" /><line x1="266" y1="75" x2="266" y2="550" stroke-width="0.6" class="stroke-eaecef" /><line x1="536" y1="75" x2="536" y2="550" stroke-width="0.6" class="stroke-eaecef" /><line x1="806" y1="75" x2="806" y2="550" stroke-width="0.6" class="stroke-eaecef" /><text class="caption" x="30" y="30"><tspan class="caption-muted">Figure 4: </tspan>Codec-aligned sampling vs. uniform frame sampling.</text>
+<g transform="translate(730, 26)">
+
+<line x1="0" y1="0" x2="30" y2="0" stroke-width="1.8" class="stroke-1a1a1a" />
+<text class="tick" x="36" y="4">codec-aligned</text>
+
+<line x1="125" y1="0" x2="155" y2="0" stroke-width="1.3" stroke-dasharray="3 2" class="stroke-8c959f" />
+<text class="tick" x="161" y="4">uniform frame</text>
+<rect x="250" y="-6" width="16" height="12" opacity="0.6" class="fill-fef3c7" />
+<text class="tick" x="272" y="4">codec advantage</text>
+</g>
+<g id="cvf-panel-0" transform="translate(-12.00,-24.00)" style="animation-delay:0.00s">
+<text x="48" y="99" class="panel-title">TimeLens-QVHighlights</text>
+<text x="48" y="111" class="subhead">peak +26.6  ·  4f Δ +15.4  ·  64f Δ +1.8</text>
+
+<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid" />
+<text x="42" y="297.0" text-anchor="end" class="tick">10</text>
+
+<line x1="48" y1="234.0" x2="238" y2="234.0" class="grid" />
+<text x="42" y="237.0" text-anchor="end" class="tick">30</text>
+
+<line x1="48" y1="174.0" x2="238" y2="174.0" class="grid" />
+<text x="42" y="177.0" text-anchor="end" class="tick">50</text>
+
+<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid" />
+<text x="42" y="117.0" text-anchor="end" class="tick">70</text>
+<text x="48.0" y="316.0" text-anchor="middle" class="tick">4</text>
+<text x="143.0" y="316.0" text-anchor="middle" class="tick">16</text>
+<text x="238.0" y="316.0" text-anchor="middle" class="tick">64</text>
+<line class="grid" x1="48.0" y1="114" x2="48.0" y2="294" /><line class="grid" x1="143.0" y1="114" x2="143.0" y2="294" /><line class="grid" x1="238.0" y1="114" x2="238.0" y2="294" /><polygon points="48.0,287.1 95.5,254.1 143.0,249.3 190.5,164.4 238.0,138.9 238.0,133.5 190.5,146.4 143.0,169.5 95.5,202.8 48.0,240.9" opacity="0.4" class="fill-fef3c7" />
+
+<line x1="48" y1="114" x2="48" y2="294" class="axis" />
+
+<line x1="48" y1="294" x2="238" y2="294" class="axis" />
+<polyline points="48.0,287.1 95.5,254.1 143.0,249.3 190.5,164.4 238.0,138.9" fill="none" stroke-width="1.3" stroke-dasharray="3 2" class="stroke-8c959f" />
+<polyline class="codec-line stroke-1a1a1a" points="48.0,240.9 95.5,202.8 143.0,169.5 190.5,146.4 238.0,133.5" fill="none" stroke-width="1.8" />
+<text x="244" y="133.5" class="score-codec">63.5</text>
+<text x="244" y="146.9" class="score-frame">61.7</text>
+</g>
+<g id="cvf-panel-1" transform="translate(258.00,-24.00)" style="animation-delay:0.08s">
+<text x="48" y="99" class="panel-title">TimeLens-Charades-STA</text>
+<text x="48" y="111" class="subhead">peak +25.0  ·  4f Δ +25.0  ·  64f Δ -3.4</text>
+
+<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid" />
+<text x="42" y="297.0" text-anchor="end" class="tick">15</text>
+
+<line x1="48" y1="204.0" x2="238" y2="204.0" class="grid" />
+<text x="42" y="207.0" text-anchor="end" class="tick">35</text>
+
+<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid" />
+<text x="42" y="117.0" text-anchor="end" class="tick">55</text>
+<text x="48.0" y="316.0" text-anchor="middle" class="tick">4</text>
+<text x="143.0" y="316.0" text-anchor="middle" class="tick">16</text>
+<text x="238.0" y="316.0" text-anchor="middle" class="tick">64</text>
+<line class="grid" x1="48.0" y1="114" x2="48.0" y2="294" /><line class="grid" x1="143.0" y1="114" x2="143.0" y2="294" /><line class="grid" x1="238.0" y1="114" x2="238.0" y2="294" /><polygon points="48.0,283.2 95.5,194.6 143.0,145.1 190.5,122.6 238.0,120.8 238.0,136.0 190.5,137.0 143.0,132.0 95.5,144.6 48.0,170.7" opacity="0.4" class="fill-fef3c7" />
+
+<line x1="48" y1="114" x2="48" y2="294" class="axis" />
+
+<line x1="48" y1="294" x2="238" y2="294" class="axis" />
+<polyline points="48.0,283.2 95.5,194.6 143.0,145.1 190.5,122.6 238.0,120.8" fill="none" stroke-width="1.3" stroke-dasharray="3 2" class="stroke-8c959f" />
+<polyline class="codec-line stroke-1a1a1a" points="48.0,170.7 95.5,144.6 143.0,132.0 190.5,137.0 238.0,136.0" fill="none" stroke-width="1.8" />
+<text x="244" y="140.0" class="score-codec">50.1</text>
+<text x="244" y="124.8" class="score-frame">53.5</text>
+</g>
+<g id="cvf-panel-2" transform="translate(528.00,-24.00)" style="animation-delay:0.16s">
+<text x="48" y="99" class="panel-title">TimeLens-ActivityNet</text>
+<text x="48" y="111" class="subhead">peak +13.3  ·  4f Δ +11.1  ·  64f Δ +2.3</text>
+
+<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid" />
+<text x="42" y="297.0" text-anchor="end" class="tick">10</text>
+
+<line x1="48" y1="234.0" x2="238" y2="234.0" class="grid" />
+<text x="42" y="237.0" text-anchor="end" class="tick">25</text>
+
+<line x1="48" y1="174.0" x2="238" y2="174.0" class="grid" />
+<text x="42" y="177.0" text-anchor="end" class="tick">40</text>
+
+<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid" />
+<text x="42" y="117.0" text-anchor="end" class="tick">55</text>
+<text x="48.0" y="316.0" text-anchor="middle" class="tick">4</text>
+<text x="143.0" y="316.0" text-anchor="middle" class="tick">16</text>
+<text x="238.0" y="316.0" text-anchor="middle" class="tick">64</text>
+<line class="grid" x1="48.0" y1="114" x2="48.0" y2="294" /><line class="grid" x1="143.0" y1="114" x2="143.0" y2="294" /><line class="grid" x1="238.0" y1="114" x2="238.0" y2="294" /><polygon points="48.0,286.0 95.5,260.0 143.0,221.6 190.5,174.4 238.0,138.4 238.0,129.2 190.5,144.0 143.0,171.6 95.5,206.8 48.0,241.6" opacity="0.4" class="fill-fef3c7" />
+
+<line x1="48" y1="114" x2="48" y2="294" class="axis" />
+
+<line x1="48" y1="294" x2="238" y2="294" class="axis" />
+<polyline points="48.0,286.0 95.5,260.0 143.0,221.6 190.5,174.4 238.0,138.4" fill="none" stroke-width="1.3" stroke-dasharray="3 2" class="stroke-8c959f" />
+<polyline class="codec-line stroke-1a1a1a" points="48.0,241.6 95.5,206.8 143.0,171.6 190.5,144.0 238.0,129.2" fill="none" stroke-width="1.8" />
+<text x="244" y="129.2" class="score-codec">51.2</text>
+<text x="244" y="146.4" class="score-frame">48.9</text>
+</g>
+<g id="cvf-panel-3" transform="translate(798.00,-24.00)" style="animation-delay:0.24s">
+<text x="48" y="99" class="panel-title">LVBench</text>
+<text x="48" y="111" class="subhead">peak +2.0  ·  16f Δ +2.0  ·  128f Δ +1.8</text>
+
+<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid" />
+<text x="42" y="297.0" text-anchor="end" class="tick">36</text>
+
+<line x1="48" y1="204.0" x2="238" y2="204.0" class="grid" />
+<text x="42" y="207.0" text-anchor="end" class="tick">44</text>
+
+<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid" />
+<text x="42" y="117.0" text-anchor="end" class="tick">52</text>
+<text x="48.0" y="316.0" text-anchor="middle" class="tick">16</text>
+<text x="174.7" y="316.0" text-anchor="middle" class="tick">64</text>
+<text x="238.0" y="316.0" text-anchor="middle" class="tick">128</text>
+<line class="grid" x1="48.0" y1="114" x2="48.0" y2="294" /><line class="grid" x1="174.7" y1="114" x2="174.7" y2="294" /><line class="grid" x1="238.0" y1="114" x2="238.0" y2="294" /><polygon points="48.0,261.4 111.3,231.0 174.7,186.0 238.0,162.4 238.0,142.1 174.7,169.1 111.3,216.4 48.0,238.9" opacity="0.4" class="fill-fef3c7" />
+
+<line x1="48" y1="114" x2="48" y2="294" class="axis" />
+
+<line x1="48" y1="294" x2="238" y2="294" class="axis" />
+<polyline points="48.0,261.4 111.3,231.0 174.7,186.0 238.0,162.4" fill="none" stroke-width="1.3" stroke-dasharray="3 2" class="stroke-8c959f" />
+<polyline class="codec-line stroke-1a1a1a" points="48.0,238.9 111.3,216.4 174.7,169.1 238.0,142.1" fill="none" stroke-width="1.8" />
+<text x="244" y="146.1" class="score-codec">49.5</text>
+<text x="244" y="166.4" class="score-frame">47.7</text>
+</g>
+<g id="cvf-panel-4" transform="translate(-12.00,256.00)" style="animation-delay:0.32s">
+<text x="48" y="99" class="panel-title">VideoMME-Long-Sub</text>
+<text x="48" y="111" class="subhead">peak +7.2  ·  8f Δ +6.2  ·  128f Δ +4.4</text>
+
+<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid" />
+<text x="42" y="297.0" text-anchor="end" class="tick">50</text>
+
+<line x1="48" y1="204.0" x2="238" y2="204.0" class="grid" />
+<text x="42" y="207.0" text-anchor="end" class="tick">60</text>
+
+<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid" />
+<text x="42" y="117.0" text-anchor="end" class="tick">70</text>
+<text x="48.0" y="316.0" text-anchor="middle" class="tick">8</text>
+<text x="95.5" y="316.0" text-anchor="middle" class="tick">16</text>
+<text x="190.5" y="316.0" text-anchor="middle" class="tick">64</text>
+<text x="238.0" y="316.0" text-anchor="middle" class="tick">128</text>
+<line class="grid" x1="48.0" y1="114" x2="48.0" y2="294" /><line class="grid" x1="95.5" y1="114" x2="95.5" y2="294" /><line class="grid" x1="190.5" y1="114" x2="190.5" y2="294" /><line class="grid" x1="238.0" y1="114" x2="238.0" y2="294" /><polygon points="48.0,287.7 95.5,249.0 143.0,228.3 190.5,211.2 238.0,175.2 238.0,135.6 190.5,146.4 143.0,176.1 95.5,211.2 48.0,231.9" opacity="0.4" class="fill-fef3c7" />
+
+<line x1="48" y1="114" x2="48" y2="294" class="axis" />
+
+<line x1="48" y1="294" x2="238" y2="294" class="axis" />
+<polyline points="48.0,287.7 95.5,249.0 143.0,228.3 190.5,211.2 238.0,175.2" fill="none" stroke-width="1.3" stroke-dasharray="3 2" class="stroke-8c959f" />
+<polyline class="codec-line stroke-1a1a1a" points="48.0,231.9 95.5,211.2 143.0,176.1 190.5,146.4 238.0,135.6" fill="none" stroke-width="1.8" />
+<text x="244" y="139.6" class="score-codec">67.6</text>
+<text x="244" y="179.2" class="score-frame">63.2</text>
+</g>
+<g id="cvf-panel-5" transform="translate(258.00,256.00)" style="animation-delay:0.40s">
+<text x="48" y="99" class="panel-title">VideoEval-Pro</text>
+<text x="48" y="111" class="subhead">peak +3.4  ·  8f Δ +3.1  ·  128f Δ +1.5</text>
+
+<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid" />
+<text x="42" y="297.0" text-anchor="end" class="tick">42</text>
+
+<line x1="48" y1="204.0" x2="238" y2="204.0" class="grid" />
+<text x="42" y="207.0" text-anchor="end" class="tick">50</text>
+
+<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid" />
+<text x="42" y="117.0" text-anchor="end" class="tick">58</text>
+<text x="48.0" y="316.0" text-anchor="middle" class="tick">8</text>
+<text x="95.5" y="316.0" text-anchor="middle" class="tick">16</text>
+<text x="190.5" y="316.0" text-anchor="middle" class="tick">64</text>
+<text x="238.0" y="316.0" text-anchor="middle" class="tick">128</text>
+<line class="grid" x1="48.0" y1="114" x2="48.0" y2="294" /><line class="grid" x1="95.5" y1="114" x2="95.5" y2="294" /><line class="grid" x1="190.5" y1="114" x2="190.5" y2="294" /><line class="grid" x1="238.0" y1="114" x2="238.0" y2="294" /><polygon points="48.0,281.6 95.5,262.5 143.0,219.8 190.5,178.1 238.0,159.0 238.0,142.1 190.5,162.4 143.0,188.2 95.5,224.2 48.0,246.7" opacity="0.4" class="fill-fef3c7" />
+
+<line x1="48" y1="114" x2="48" y2="294" class="axis" />
+
+<line x1="48" y1="294" x2="238" y2="294" class="axis" />
+<polyline points="48.0,281.6 95.5,262.5 143.0,219.8 190.5,178.1 238.0,159.0" fill="none" stroke-width="1.3" stroke-dasharray="3 2" class="stroke-8c959f" />
+<polyline class="codec-line stroke-1a1a1a" points="48.0,246.7 95.5,224.2 143.0,188.2 190.5,162.4 238.0,142.1" fill="none" stroke-width="1.8" />
+<text x="244" y="146.1" class="score-codec">55.5</text>
+<text x="244" y="163.0" class="score-frame">54.0</text>
+</g>
+<g id="cvf-panel-6" transform="translate(528.00,256.00)" style="animation-delay:0.48s">
+<text x="48" y="99" class="panel-title">OV-Rope</text>
+<text x="48" y="111" class="subhead">peak +21.4  ·  16f Δ +2.8  ·  128f Δ +19.0</text>
+
+<line x1="48" y1="294.0" x2="238" y2="294.0" class="grid" />
+<text x="42" y="297.0" text-anchor="end" class="tick">35</text>
+
+<line x1="48" y1="234.0" x2="238" y2="234.0" class="grid" />
+<text x="42" y="237.0" text-anchor="end" class="tick">45</text>
+
+<line x1="48" y1="174.0" x2="238" y2="174.0" class="grid" />
+<text x="42" y="177.0" text-anchor="end" class="tick">55</text>
+
+<line x1="48" y1="114.0" x2="238" y2="114.0" class="grid" />
+<text x="42" y="117.0" text-anchor="end" class="tick">65</text>
+<text x="48.0" y="316.0" text-anchor="middle" class="tick">16</text>
+<text x="174.7" y="316.0" text-anchor="middle" class="tick">64</text>
+<text x="238.0" y="316.0" text-anchor="middle" class="tick">128</text>
+<line class="grid" x1="48.0" y1="114" x2="48.0" y2="294" /><line class="grid" x1="174.7" y1="114" x2="174.7" y2="294" /><line class="grid" x1="238.0" y1="114" x2="238.0" y2="294" /><polygon points="48.0,279.6 111.3,286.8 174.7,277.8 238.0,247.2 238.0,133.2 174.7,149.4 111.3,202.2 48.0,262.8" opacity="0.4" class="fill-fef3c7" />
+
+<line x1="48" y1="114" x2="48" y2="294" class="axis" />
+
+<line x1="48" y1="294" x2="238" y2="294" class="axis" />
+<polyline points="48.0,279.6 111.3,286.8 174.7,277.8 238.0,247.2" fill="none" stroke-width="1.3" stroke-dasharray="3 2" class="stroke-8c959f" />
+<polyline class="codec-line stroke-1a1a1a" points="48.0,262.8 111.3,202.2 174.7,149.4 238.0,133.2" fill="none" stroke-width="1.8" />
+<text x="244" y="137.2" class="score-codec">61.8</text>
+<text x="244" y="251.2" class="score-frame">42.8</text>
+</g>
+<g id="cvf-panel-7" transform="translate(798.00,256.00)" style="animation-delay:0.56s">
+<text x="48" y="99" class="panel-title">Overall Averages</text>
+<text x="48" y="140" class="subhead fill-1a1a1a">Average Peak Δ</text>
+<text x="210" y="140" class="score-codec fill-1a1a1a">+14.1</text>
+<text x="48" y="170" class="subhead fill-1a1a1a">Codec @ Max (Avg)</text>
+<text x="210" y="170" class="score-codec fill-1a1a1a">57.0</text>
+<text x="48" y="200" class="subhead fill-1a1a1a">Frame @ Max (Avg)</text>
+<text x="210" y="200" class="score-frame">53.0</text>
+<text x="48" y="250" class="subhead fill-6a737d">Codec sampling consistently</text>
+<text x="48" y="270" class="subhead fill-6a737d">extends temporal coverage and</text>
+<text x="48" y="290" class="subhead fill-6a737d">peak performance overall.</text>
+</g>
+</svg>

--- a/asset/method_unified_encoder_dark.svg
+++ b/asset/method_unified_encoder_dark.svg
@@ -1,55 +1,32 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 820" font-family="-apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif">
   <defs>
     <style><![CDATA[
-.title { font-size: 38px; font-weight: 700; fill: #0f172a; }
-      .subtitle { font-size: 18px; font-weight: 500; fill: #64748b; letter-spacing: 0.04em; text-transform: uppercase; }
-      .panel-title { font-size: 24px; font-weight: 600; fill: #0f172a; }
-      .panel-sub { font-size: 16px; font-weight: 400; fill: #64748b; }
+.title { font-size: 38px; font-weight: 700; fill: #f0f6fc; }
+      .subtitle { font-size: 18px; font-weight: 500; fill: #8b949e; letter-spacing: 0.04em; text-transform: uppercase; }
+      .panel-title { font-size: 24px; font-weight: 600; fill: #f0f6fc; }
+      .panel-sub { font-size: 16px; font-weight: 400; fill: #8b949e; }
       .stat-num { font-size: 36px; font-weight: 700; }
-      .stat-label { font-size: 13px; font-weight: 500; fill: #64748b; letter-spacing: 0.05em; text-transform: uppercase; }
+      .stat-label { font-size: 13px; font-weight: 500; fill: #8b949e; letter-spacing: 0.05em; text-transform: uppercase; }
       .pos-label { font-size: 16px; font-weight: 700; font-family: 'SF Mono', 'Menlo', 'Consolas', monospace; }
       .pos-num { font-size: 15px; font-weight: 500; font-family: 'SF Mono', 'Menlo', 'Consolas', monospace; }
-      .legend-text { font-size: 15px; font-weight: 500; fill: #334155; }
-      .divider { stroke: #e2e8f0; stroke-width: 1; }
+      .legend-text { font-size: 15px; font-weight: 500; fill: #b8c0c8; }
+      .divider { stroke: #30363d; stroke-width: 1; }
 
     /* Extracted Inline Colors */
-    .fill-ffffff { fill: #ffffff; }
-    .fill-2563eb { fill: #2563eb; }
-    .fill-0f172a { fill: #0f172a; }
-    .fill-f8fafc { fill: #f8fafc; }
-    .stroke-0f172a { stroke: #0f172a; }
-    .fill-334155 { fill: #334155; }
-    .stroke-94a3b8 { stroke: #94a3b8; }
-    .fill-94a3b8 { fill: #94a3b8; }
+    .fill-ffffff { fill: #0d1117; }
+    .fill-2563eb { fill: #58a6ff; }
+    .fill-0f172a { fill: #f0f6fc; }
+    .fill-f8fafc { fill: #161b22; }
+    .stroke-0f172a { stroke: #f0f6fc; }
+    .fill-334155 { fill: #b8c0c8; }
+    .stroke-94a3b8 { stroke: #6e7681; }
+    .fill-94a3b8 { fill: #6e7681; }
     .fill-f59e0b { fill: #f59e0b; }
-    .stroke-cbd5e1 { stroke: #cbd5e1; }
-    .fill-9a3412 { fill: #9a3412; }
-    .fill-15803d { fill: #15803d; }
-    .fill-1d4ed8 { fill: #1d4ed8; }
-    .fill-0d9488 { fill: #0d9488; }
-
-    @media (prefers-color-scheme: dark) {
-      .title { fill: #f0f6fc; }
-      .subtitle { fill: #8b949e; }
-      .panel-title { fill: #f0f6fc; }
-      .panel-sub { fill: #8b949e; }
-      .stat-label { fill: #8b949e; }
-      .legend-text { fill: #b8c0c8; }
-      .divider { stroke: #30363d; }
-      .fill-ffffff { fill: #0d1117; }
-      .fill-2563eb { fill: #58a6ff; }
-      .fill-0f172a { fill: #f0f6fc; }
-      .fill-f8fafc { fill: #161b22; }
-      .stroke-0f172a { stroke: #f0f6fc; }
-      .fill-334155 { fill: #b8c0c8; }
-      .stroke-94a3b8 { stroke: #6e7681; }
-      .fill-94a3b8 { fill: #6e7681; }
-      .stroke-cbd5e1 { stroke: #484f58; }
-      .fill-9a3412 { fill: #f0a868; }
-      .fill-15803d { fill: #56d364; }
-      .fill-1d4ed8 { fill: #58a6ff; }
-      .fill-0d9488 { fill: #2dd4bf; }
-    }
+    .stroke-cbd5e1 { stroke: #484f58; }
+    .fill-9a3412 { fill: #f0a868; }
+    .fill-15803d { fill: #56d364; }
+    .fill-1d4ed8 { fill: #58a6ff; }
+    .fill-0d9488 { fill: #2dd4bf; }
   ]]></style>
   </defs>
   <rect width="1080" height="820" class="fill-ffffff" />

--- a/asset/method_unified_encoder_light.svg
+++ b/asset/method_unified_encoder_light.svg
@@ -1,0 +1,429 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 820" font-family="-apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif">
+  <defs>
+    <style><![CDATA[
+.title { font-size: 38px; font-weight: 700; fill: #0f172a; }
+      .subtitle { font-size: 18px; font-weight: 500; fill: #64748b; letter-spacing: 0.04em; text-transform: uppercase; }
+      .panel-title { font-size: 24px; font-weight: 600; fill: #0f172a; }
+      .panel-sub { font-size: 16px; font-weight: 400; fill: #64748b; }
+      .stat-num { font-size: 36px; font-weight: 700; }
+      .stat-label { font-size: 13px; font-weight: 500; fill: #64748b; letter-spacing: 0.05em; text-transform: uppercase; }
+      .pos-label { font-size: 16px; font-weight: 700; font-family: 'SF Mono', 'Menlo', 'Consolas', monospace; }
+      .pos-num { font-size: 15px; font-weight: 500; font-family: 'SF Mono', 'Menlo', 'Consolas', monospace; }
+      .legend-text { font-size: 15px; font-weight: 500; fill: #334155; }
+      .divider { stroke: #e2e8f0; stroke-width: 1; }
+
+    /* Extracted Inline Colors */
+    .fill-ffffff { fill: #ffffff; }
+    .fill-2563eb { fill: #2563eb; }
+    .fill-0f172a { fill: #0f172a; }
+    .fill-f8fafc { fill: #f8fafc; }
+    .stroke-0f172a { stroke: #0f172a; }
+    .fill-334155 { fill: #334155; }
+    .stroke-94a3b8 { stroke: #94a3b8; }
+    .fill-94a3b8 { fill: #94a3b8; }
+    .fill-f59e0b { fill: #f59e0b; }
+    .stroke-cbd5e1 { stroke: #cbd5e1; }
+    .fill-9a3412 { fill: #9a3412; }
+    .fill-15803d { fill: #15803d; }
+    .fill-1d4ed8 { fill: #1d4ed8; }
+    .fill-0d9488 { fill: #0d9488; }
+  ]]></style>
+  </defs>
+  <rect width="1080" height="820" class="fill-ffffff" />
+
+  <text x="60" y="44" class="subtitle">Figure 2 · One Encoder, Every Modality</text>
+  <text x="60" y="80" class="title">OneVision-Encoder.</text>
+  <text x="60" y="124" class="title">Three input types. Same token grid.</text>
+  <text x="60" y="156" class="panel-sub">All three input types flow through the <tspan font-weight="700" class="fill-2563eb">same OneVision-Encoder</tspan> under shared <tspan font-weight="700" font-family="'SF Mono', 'Menlo', monospace" class="fill-0f172a">(t, h, w)</tspan> positions.</text>
+  <line x1="60" y1="174" x2="1020" y2="174" class="divider" />
+
+  <g>
+    <rect x="60" y="208" width="960" height="52" rx="6" stroke-width="1.5" class="fill-f8fafc stroke-0f172a" />
+    <text x="540.0" y="230" text-anchor="middle" class="panel-title">OneVision-Encoder · 24 Layers</text>
+    <text x="540.0" y="250" text-anchor="middle" class="panel-sub">Shared encoder · positions <tspan font-family="'SF Mono', 'Menlo', monospace" class="fill-334155">(t, h, w)</tspan></text>
+  </g>
+
+  <line x1="540.0" y1="262" x2="540.0" y2="270" stroke-width="1.5" stroke-dasharray="3 3" class="stroke-94a3b8" />
+  <polygon points="536,270 544,270 540,276" class="fill-94a3b8" />
+
+  <g>
+    <rect x="60" y="274" width="3" height="162" rx="1.5" class="fill-f59e0b" />
+    <text x="74" y="298" class="panel-title">Image</text>
+    <text x="74" y="320" class="panel-sub">1 frame · 9 patches · single time step</text>
+    <text x="1020" y="300" text-anchor="end" class="stat-num fill-f59e0b">9</text>
+    <text x="1020" y="318" text-anchor="end" class="stat-label">tokens</text>
+    <rect x="138" y="344" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="165" y="344" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="192" y="344" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="219" y="344" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="246" y="344" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="273" y="344" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="300" y="344" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="327" y="344" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="354" y="344" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="381" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="408" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="435" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="462" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="489" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="516" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="543" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="570" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="597" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="624" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="651" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="678" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="705" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="732" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="759" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="786" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="813" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="840" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="867" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="894" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="921" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="948" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <rect x="975" y="344" width="23" height="23" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <text x="74" y="389" class="pos-label fill-9a3412">t:</text>
+    <text x="149.5" y="389" text-anchor="middle" class="pos-num fill-9a3412">0</text>
+    <text x="176.5" y="389" text-anchor="middle" class="pos-num fill-9a3412">0</text>
+    <text x="203.5" y="389" text-anchor="middle" class="pos-num fill-9a3412">0</text>
+    <text x="230.5" y="389" text-anchor="middle" class="pos-num fill-9a3412">0</text>
+    <text x="257.5" y="389" text-anchor="middle" class="pos-num fill-9a3412">0</text>
+    <text x="284.5" y="389" text-anchor="middle" class="pos-num fill-9a3412">0</text>
+    <text x="311.5" y="389" text-anchor="middle" class="pos-num fill-9a3412">0</text>
+    <text x="338.5" y="389" text-anchor="middle" class="pos-num fill-9a3412">0</text>
+    <text x="365.5" y="389" text-anchor="middle" class="pos-num fill-9a3412">0</text>
+    <text x="74" y="405" class="pos-label fill-15803d">h:</text>
+    <text x="149.5" y="405" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="176.5" y="405" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="203.5" y="405" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="230.5" y="405" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="257.5" y="405" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="284.5" y="405" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="311.5" y="405" text-anchor="middle" class="pos-num fill-15803d">2</text>
+    <text x="338.5" y="405" text-anchor="middle" class="pos-num fill-15803d">2</text>
+    <text x="365.5" y="405" text-anchor="middle" class="pos-num fill-15803d">2</text>
+    <text x="74" y="421" class="pos-label fill-1d4ed8">w:</text>
+    <text x="149.5" y="421" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="176.5" y="421" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="203.5" y="421" text-anchor="middle" class="pos-num fill-1d4ed8">2</text>
+    <text x="230.5" y="421" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="257.5" y="421" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="284.5" y="421" text-anchor="middle" class="pos-num fill-1d4ed8">2</text>
+    <text x="311.5" y="421" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="338.5" y="421" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="365.5" y="421" text-anchor="middle" class="pos-num fill-1d4ed8">2</text>
+  </g>
+
+  <g>
+    <rect x="60" y="438" width="3" height="162" rx="1.5" class="fill-2563eb" />
+    <text x="74" y="462" class="panel-title">Uniform Frames</text>
+    <text x="74" y="484" class="panel-sub">8 frames sampled uniformly · 4 patches per frame</text>
+    <text x="1020" y="464" text-anchor="end" class="stat-num fill-2563eb">32</text>
+    <text x="1020" y="482" text-anchor="end" class="stat-label">tokens</text>
+    <rect x="138" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="165" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="192" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="219" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="246" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="273" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="300" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="327" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="354" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="381" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="408" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="435" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="462" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="489" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="516" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="543" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="570" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="597" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="624" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="651" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="678" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="705" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="732" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="759" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="786" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="813" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="840" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="867" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="894" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="921" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="948" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <rect x="975" y="508" width="23" height="23" rx="2" opacity="0.85" class="fill-2563eb" />
+    <text x="74" y="553" class="pos-label fill-9a3412">t:</text>
+    <text x="149.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">0</text>
+    <text x="176.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">0</text>
+    <text x="203.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">0</text>
+    <text x="230.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">0</text>
+    <text x="257.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">1</text>
+    <text x="284.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">1</text>
+    <text x="311.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">1</text>
+    <text x="338.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">1</text>
+    <text x="365.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">2</text>
+    <text x="392.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">2</text>
+    <text x="419.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">2</text>
+    <text x="446.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">2</text>
+    <text x="473.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">3</text>
+    <text x="500.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">3</text>
+    <text x="527.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">3</text>
+    <text x="554.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">3</text>
+    <text x="581.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">4</text>
+    <text x="608.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">4</text>
+    <text x="635.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">4</text>
+    <text x="662.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">4</text>
+    <text x="689.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">5</text>
+    <text x="716.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">5</text>
+    <text x="743.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">5</text>
+    <text x="770.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">5</text>
+    <text x="797.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">6</text>
+    <text x="824.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">6</text>
+    <text x="851.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">6</text>
+    <text x="878.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">6</text>
+    <text x="905.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">7</text>
+    <text x="932.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">7</text>
+    <text x="959.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">7</text>
+    <text x="986.5" y="553" text-anchor="middle" class="pos-num fill-9a3412">7</text>
+    <text x="74" y="569" class="pos-label fill-15803d">h:</text>
+    <text x="149.5" y="569" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="176.5" y="569" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="203.5" y="569" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="230.5" y="569" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="257.5" y="569" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="284.5" y="569" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="311.5" y="569" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="338.5" y="569" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="365.5" y="569" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="392.5" y="569" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="419.5" y="569" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="446.5" y="569" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="473.5" y="569" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="500.5" y="569" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="527.5" y="569" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="554.5" y="569" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="581.5" y="569" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="608.5" y="569" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="635.5" y="569" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="662.5" y="569" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="689.5" y="569" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="716.5" y="569" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="743.5" y="569" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="770.5" y="569" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="797.5" y="569" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="824.5" y="569" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="851.5" y="569" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="878.5" y="569" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="905.5" y="569" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="932.5" y="569" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="959.5" y="569" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="986.5" y="569" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="74" y="585" class="pos-label fill-1d4ed8">w:</text>
+    <text x="149.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="176.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="203.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="230.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="257.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="284.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="311.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="338.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="365.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="392.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="419.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="446.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="473.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="500.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="527.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="554.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="581.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="608.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="635.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="662.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="689.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="716.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="743.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="770.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="797.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="824.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="851.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="878.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="905.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="932.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="959.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="986.5" y="585" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+  </g>
+
+  <g>
+    <rect x="60" y="602" width="3" height="162" rx="1.5" class="fill-0d9488" />
+    <text x="74" y="626" class="panel-title">Codec-Aligned</text>
+    <text x="74" y="648" class="panel-sub">32 frames · I-frame patches + P-frame motion patches</text>
+    <text x="1020" y="628" text-anchor="end" class="stat-num fill-0d9488">32</text>
+    <text x="1020" y="646" text-anchor="end" class="stat-label">tokens</text>
+    <rect x="138" y="672" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="165" y="672" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="192" y="672" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="219" y="672" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="246" y="672" width="23" height="23" rx="2" fill="none" stroke-width="1" stroke-dasharray="2 2" class="stroke-94a3b8" />
+    <rect x="253.5" y="679.5" width="8" height="8" rx="1" opacity="0.9" class="fill-f59e0b" />
+    <rect x="273" y="672" width="23" height="23" rx="2" fill="none" stroke-width="1" stroke-dasharray="2 2" class="stroke-94a3b8" />
+    <rect x="280.5" y="679.5" width="8" height="8" rx="1" opacity="0.9" class="fill-f59e0b" />
+    <rect x="300" y="672" width="23" height="23" rx="2" fill="none" stroke-width="1" stroke-dasharray="2 2" class="stroke-94a3b8" />
+    <rect x="307.5" y="679.5" width="8" height="8" rx="1" opacity="0.9" class="fill-f59e0b" />
+    <rect x="327" y="672" width="23" height="23" rx="2" fill="none" stroke-width="1" stroke-dasharray="2 2" class="stroke-94a3b8" />
+    <rect x="334.5" y="679.5" width="8" height="8" rx="1" opacity="0.9" class="fill-f59e0b" />
+    <rect x="354" y="672" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="381" y="672" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="408" y="672" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="435" y="672" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="462" y="672" width="23" height="23" rx="2" fill="none" stroke-width="1" stroke-dasharray="2 2" class="stroke-94a3b8" />
+    <rect x="469.5" y="679.5" width="8" height="8" rx="1" opacity="0.9" class="fill-f59e0b" />
+    <rect x="489" y="672" width="23" height="23" rx="2" fill="none" stroke-width="1" stroke-dasharray="2 2" class="stroke-94a3b8" />
+    <rect x="496.5" y="679.5" width="8" height="8" rx="1" opacity="0.9" class="fill-f59e0b" />
+    <rect x="516" y="672" width="23" height="23" rx="2" fill="none" stroke-width="1" stroke-dasharray="2 2" class="stroke-94a3b8" />
+    <rect x="523.5" y="679.5" width="8" height="8" rx="1" opacity="0.9" class="fill-f59e0b" />
+    <rect x="543" y="672" width="23" height="23" rx="2" fill="none" stroke-width="1" stroke-dasharray="2 2" class="stroke-94a3b8" />
+    <rect x="550.5" y="679.5" width="8" height="8" rx="1" opacity="0.9" class="fill-f59e0b" />
+    <rect x="570" y="672" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="597" y="672" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="624" y="672" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="651" y="672" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="678" y="672" width="23" height="23" rx="2" fill="none" stroke-width="1" stroke-dasharray="2 2" class="stroke-94a3b8" />
+    <rect x="685.5" y="679.5" width="8" height="8" rx="1" opacity="0.9" class="fill-f59e0b" />
+    <rect x="705" y="672" width="23" height="23" rx="2" fill="none" stroke-width="1" stroke-dasharray="2 2" class="stroke-94a3b8" />
+    <rect x="712.5" y="679.5" width="8" height="8" rx="1" opacity="0.9" class="fill-f59e0b" />
+    <rect x="732" y="672" width="23" height="23" rx="2" fill="none" stroke-width="1" stroke-dasharray="2 2" class="stroke-94a3b8" />
+    <rect x="739.5" y="679.5" width="8" height="8" rx="1" opacity="0.9" class="fill-f59e0b" />
+    <rect x="759" y="672" width="23" height="23" rx="2" fill="none" stroke-width="1" stroke-dasharray="2 2" class="stroke-94a3b8" />
+    <rect x="766.5" y="679.5" width="8" height="8" rx="1" opacity="0.9" class="fill-f59e0b" />
+    <rect x="786" y="672" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="813" y="672" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="840" y="672" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="867" y="672" width="23" height="23" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <rect x="894" y="672" width="23" height="23" rx="2" fill="none" stroke-width="1" stroke-dasharray="2 2" class="stroke-94a3b8" />
+    <rect x="901.5" y="679.5" width="8" height="8" rx="1" opacity="0.9" class="fill-f59e0b" />
+    <rect x="921" y="672" width="23" height="23" rx="2" fill="none" stroke-width="1" stroke-dasharray="2 2" class="stroke-94a3b8" />
+    <rect x="928.5" y="679.5" width="8" height="8" rx="1" opacity="0.9" class="fill-f59e0b" />
+    <rect x="948" y="672" width="23" height="23" rx="2" fill="none" stroke-width="1" stroke-dasharray="2 2" class="stroke-94a3b8" />
+    <rect x="955.5" y="679.5" width="8" height="8" rx="1" opacity="0.9" class="fill-f59e0b" />
+    <rect x="975" y="672" width="23" height="23" rx="2" fill="none" stroke-width="1" stroke-dasharray="2 2" class="stroke-94a3b8" />
+    <rect x="982.5" y="679.5" width="8" height="8" rx="1" opacity="0.9" class="fill-f59e0b" />
+    <text x="74" y="717" class="pos-label fill-9a3412">t:</text>
+    <text x="149.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">0</text>
+    <text x="176.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">0</text>
+    <text x="203.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">0</text>
+    <text x="230.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">0</text>
+    <text x="257.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">2</text>
+    <text x="284.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">4</text>
+    <text x="311.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">6</text>
+    <text x="338.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">8</text>
+    <text x="365.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">8</text>
+    <text x="392.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">8</text>
+    <text x="419.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">8</text>
+    <text x="446.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">8</text>
+    <text x="473.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">10</text>
+    <text x="500.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">12</text>
+    <text x="527.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">14</text>
+    <text x="554.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">16</text>
+    <text x="581.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">16</text>
+    <text x="608.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">16</text>
+    <text x="635.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">16</text>
+    <text x="662.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">16</text>
+    <text x="689.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">18</text>
+    <text x="716.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">20</text>
+    <text x="743.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">22</text>
+    <text x="770.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">24</text>
+    <text x="797.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">24</text>
+    <text x="824.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">24</text>
+    <text x="851.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">24</text>
+    <text x="878.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">24</text>
+    <text x="905.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">26</text>
+    <text x="932.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">28</text>
+    <text x="959.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">30</text>
+    <text x="986.5" y="717" text-anchor="middle" class="pos-num fill-9a3412">32</text>
+    <text x="74" y="733" class="pos-label fill-15803d">h:</text>
+    <text x="149.5" y="733" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="176.5" y="733" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="203.5" y="733" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="230.5" y="733" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="257.5" y="733" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="284.5" y="733" text-anchor="middle" class="pos-num fill-15803d">2</text>
+    <text x="311.5" y="733" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="338.5" y="733" text-anchor="middle" class="pos-num fill-15803d">2</text>
+    <text x="365.5" y="733" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="392.5" y="733" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="419.5" y="733" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="446.5" y="733" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="473.5" y="733" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="500.5" y="733" text-anchor="middle" class="pos-num fill-15803d">2</text>
+    <text x="527.5" y="733" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="554.5" y="733" text-anchor="middle" class="pos-num fill-15803d">2</text>
+    <text x="581.5" y="733" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="608.5" y="733" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="635.5" y="733" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="662.5" y="733" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="689.5" y="733" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="716.5" y="733" text-anchor="middle" class="pos-num fill-15803d">2</text>
+    <text x="743.5" y="733" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="770.5" y="733" text-anchor="middle" class="pos-num fill-15803d">2</text>
+    <text x="797.5" y="733" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="824.5" y="733" text-anchor="middle" class="pos-num fill-15803d">0</text>
+    <text x="851.5" y="733" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="878.5" y="733" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="905.5" y="733" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="932.5" y="733" text-anchor="middle" class="pos-num fill-15803d">2</text>
+    <text x="959.5" y="733" text-anchor="middle" class="pos-num fill-15803d">1</text>
+    <text x="986.5" y="733" text-anchor="middle" class="pos-num fill-15803d">2</text>
+    <text x="74" y="749" class="pos-label fill-1d4ed8">w:</text>
+    <text x="149.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="176.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="203.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="230.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="257.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">2</text>
+    <text x="284.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="311.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">2</text>
+    <text x="338.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="365.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="392.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="419.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="446.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="473.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">2</text>
+    <text x="500.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="527.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">2</text>
+    <text x="554.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="581.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="608.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="635.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="662.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="689.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">2</text>
+    <text x="716.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="743.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">2</text>
+    <text x="770.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="797.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="824.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="851.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="878.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">1</text>
+    <text x="905.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">2</text>
+    <text x="932.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+    <text x="959.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">2</text>
+    <text x="986.5" y="749" text-anchor="middle" class="pos-num fill-1d4ed8">0</text>
+  </g>
+
+  <line x1="60" y1="770" x2="1020" y2="770" class="divider" />
+  <g transform="translate(60, 796)">
+    <rect x="0" y="-13" width="16" height="16" rx="2" opacity="0.9" class="fill-f59e0b" />
+    <text x="24" y="0" class="legend-text">Image / I-frame patch</text>
+
+    <rect x="220" y="-13" width="16" height="16" rx="2" opacity="0.85" class="fill-2563eb" />
+    <text x="244" y="0" class="legend-text">Uniform frame patch</text>
+
+    <rect x="450" y="-13" width="16" height="16" rx="2" fill="none" stroke-width="1" stroke-dasharray="2 2" class="stroke-94a3b8" />
+    <rect x="454" y="-9" width="8" height="8" rx="1" opacity="0.9" class="fill-f59e0b" />
+    <text x="474" y="0" class="legend-text">P-frame motion patch</text>
+
+    <rect x="690" y="-13" width="16" height="16" rx="2" fill="none" stroke-width="0.8" stroke-dasharray="1.5 1.5" class="stroke-cbd5e1" />
+    <text x="714" y="0" class="legend-text">Empty slot</text>
+  </g>
+
+</svg>


### PR DESCRIPTION
## Summary

Follow-up to #114. The in-SVG `@media (prefers-color-scheme: dark)` approach merged in #114 does **not** render correctly on GitHub mobile — the dark variant fails to activate even when the system theme is dark.

This PR replaces it with the canonical, mobile-compatible pattern: two SVG files per figure (`_light.svg` + `_dark.svg`) wrapped in a `<picture>` element with explicit `<source media="(prefers-color-scheme: ...)">` selectors. This matches the existing convention already used by `llava_onevision2_performance_*_anim.svg` and `llava_onevision2_data_distribution_*_anim.svg`.

## Changes

- Split each of the 3 method SVGs into a `_light.svg` + `_dark.svg` pair:
  - `method_codec_vs_frame.svg` → `_light` + `_dark`
  - `method_codec_selection.svg` → `_light` + `_dark`
  - `method_unified_encoder.svg` → `_light` + `_dark`
- Removed the now-redundant in-SVG `@media (prefers-color-scheme: dark)` blocks; dark colors are baked into the `_dark.svg` defaults.
- Wrapped each `<img>` in `<picture>` with `<source>` selectors in README.md.

## Verification

- All 6 new SVGs parse cleanly as XML, contain no orphan inline hex outside `<style>`, and have the expected light/dark backgrounds (`#ffffff` / `#0d1117`).
- `_light.svg` variants are visually equivalent to the pre-#114 originals (same colors, just CSS-class-organized).
- README references all updated; no stale `method_*.svg` refs remain.