### PR TITLE
docs: fix Table 1 caption text overlap in performance figure

### DIFF
--- a/asset/llava_onevision2_performance_dark_anim.svg
+++ b/asset/llava_onevision2_performance_dark_anim.svg
@@ -1807,10 +1807,7 @@ L 1245.96 1650.4416
 " clip-path="url(#p7955fdafce)" style="fill: none; stroke-dasharray: 0.8,0.8; stroke-dashoffset: 0; stroke: #f0f6fc; stroke-width: 0.4"/>
    </g>
    <g id="text_1">
-    <text style="font-weight: 700; font-size: 22px; font-family: 'DejaVu Serif', 'Nimbus Roman', 'Times New Roman', 'Times', serif; text-anchor: start; fill: #8b949e" x="43.47" y="43.874963" transform="rotate(-0 43.47 43.874963)">Table 1: </text>
-   </g>
-   <g id="text_2">
-    <text style="font-weight: 700; font-size: 22px; font-family: 'DejaVu Serif', 'Nimbus Roman', 'Times New Roman', 'Times', serif; text-anchor: start; fill: #f0f6fc" x="104.85" y="43.874963" transform="rotate(-0 104.85 43.874963)">Benchmark comparison of LLaVA-OneVision-2.0.</text>
+    <text xml:space="preserve" style="font-weight: 700; font-size: 22px; font-family: 'DejaVu Serif', 'Nimbus Roman', 'Times New Roman', 'Times', serif; text-anchor: start" x="43.47" y="43.874963"><tspan style="fill: #8b949e">Table 1: </tspan><tspan style="fill: #f0f6fc">Benchmark comparison of LLaVA-OneVision-2.0.</tspan></text>
    </g>
    <g id="text_3">
     <text style="font-size: 17px; font-family: 'DejaVu Serif', 'Nimbus Roman', 'Times New Roman', 'Times', serif; text-anchor: start; fill: #f0f6fc" x="68.022" y="62.895737" transform="rotate(-0 68.022 62.895737)">Best</text>

--- a/asset/llava_onevision2_performance_light_anim.svg
+++ b/asset/llava_onevision2_performance_light_anim.svg
@@ -1807,10 +1807,7 @@ L 1245.96 1650.4416
 " clip-path="url(#p72c5c67eba)" style="fill: none; stroke-dasharray: 0.8,0.8; stroke-dashoffset: 0; stroke: #1a1a1a; stroke-width: 0.4"/>
    </g>
    <g id="text_1">
-    <text style="font-weight: 700; font-size: 22px; font-family: 'DejaVu Serif', 'Nimbus Roman', 'Times New Roman', 'Times', serif; text-anchor: start; fill: #6a737d" x="43.47" y="43.874963" transform="rotate(-0 43.47 43.874963)">Table 1: </text>
-   </g>
-   <g id="text_2">
-    <text style="font-weight: 700; font-size: 22px; font-family: 'DejaVu Serif', 'Nimbus Roman', 'Times New Roman', 'Times', serif; text-anchor: start; fill: #1a1a1a" x="104.85" y="43.874963" transform="rotate(-0 104.85 43.874963)">Benchmark comparison of LLaVA-OneVision-2.0.</text>
+    <text xml:space="preserve" style="font-weight: 700; font-size: 22px; font-family: 'DejaVu Serif', 'Nimbus Roman', 'Times New Roman', 'Times', serif; text-anchor: start" x="43.47" y="43.874963"><tspan style="fill: #6a737d">Table 1: </tspan><tspan style="fill: #1a1a1a">Benchmark comparison of LLaVA-OneVision-2.0.</tspan></text>
    </g>
    <g id="text_3">
     <text style="font-size: 17px; font-family: 'DejaVu Serif', 'Nimbus Roman', 'Times New Roman', 'Times', serif; text-anchor: start; fill: #1a1a1a" x="68.022" y="62.895737" transform="rotate(-0 68.022 62.895737)">Best</text>


### PR DESCRIPTION
## Summary

In `llava_onevision2_performance_*_anim.svg`, the caption header was split into two separate `<text>` elements positioned at the same `y` coordinate:

- `Table 1:` at `x=43.47` in muted gray
- `Benchmark comparison of LLaVA-OneVision-2.0.` at `x=104.85` in primary text color

The `x=104.85` offset was too small for the actual rendered width of `Table 1:` in 22px bold serif (~93px), so the `B` of `Benchmark` rendered right on top of the `:` and `1` of `Table 1:`, producing an illegible overlapping cluster.

## Fix

Merge the two `<text>` elements into one with two `<tspan>`s so the text lays out sequentially based on actual rendered glyph widths — no more reliance on hand-computed `x` offsets. Also added `xml:space="preserve"` so the trailing space inside the first `<tspan>` is preserved during render.

Applied to both the `_light_anim.svg` and `_dark_anim.svg` variants.

## Verification

Rendered before/after PNGs with `rsvg-convert` and visually inspected:

- **Before:** "Table 1:" partially obscured by overlapping "Benchmark…" text
- **After:** "Table 1: Benchmark comparison of LLaVA-OneVision-2.0." renders cleanly with one space between the colon and `B`, no overlap.

XML still parses (1029 elements unchanged), only the caption text node was modified.