### PR TITLE
fix: update checkpoint configs, training hotfix, JPEG packing, and docs cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ And unlike most "open" releases, *everything* ships alongside them: encoder weig
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="asset/method_codec_vs_frame_dark.svg">
     <source media="(prefers-color-scheme: light)" srcset="asset/method_codec_vs_frame_light.svg">
-    <img src="asset/method_codec_vs_frame_light.svg" width="100%" alt="Figure 4: codec-aligned sampling compared with uniform frame sampling across video benchmarks">
+    <img src="asset/method_codec_vs_frame_light.svg" width="100%" alt="Codec-aligned sampling compared with uniform frame sampling across video benchmarks">
   </picture>
 </p>
 

--- a/aiak_training_llm/train/pretrain/pretrain_llava_onevision2.py
+++ b/aiak_training_llm/train/pretrain/pretrain_llava_onevision2.py
@@ -327,6 +327,36 @@ def forward_step(data_iterator, model):
             patch_positions=patch_positions,
         )
 
+    # HOTFIX (text-only-sample backward): when a packed sample contains no
+    # images/video AND the LLM is frozen (stage-1: --trainable-modules adapter
+    # vision_model), the vision_model+adapter are never invoked, so output_tensor
+    # has no grad_fn and custom_backward (schedules.py:161) crashes — desyncing
+    # NCCL collectives. Fix: tie a zero-magnitude contribution from the first
+    # trainable param so backward succeeds with zero gradients and DP all-reduce
+    # stays aligned. Looks like a no-op — DO NOT REMOVE.
+    if torch.is_tensor(output_tensor) and not output_tensor.requires_grad:
+        dummy_param = None
+        for _p in model.parameters():
+            if _p.requires_grad:
+                dummy_param = _p
+                break
+        if dummy_param is not None:
+            _rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+            _host = os.uname()[1]
+            print(
+                f"[hotfix-zero-grad] rank={_rank} host={_host} "
+                f"output_tensor.requires_grad=False -> tying dummy zero loss to "
+                f"trainable param shape={tuple(dummy_param.shape)} dtype={dummy_param.dtype}",
+                flush=True,
+            )
+            output_tensor = output_tensor + (dummy_param.sum() * 0.0).to(output_tensor.dtype)
+        else:
+            print(
+                "[hotfix-zero-grad] WARNING: output_tensor has no grad_fn AND no "
+                "trainable parameters found in model — backward will fail.",
+                flush=True,
+            )
+
     return output_tensor, partial(loss_func, loss_mask)
 
 

--- a/asset/method_codec_selection_dark.svg
+++ b/asset/method_codec_selection_dark.svg
@@ -31,7 +31,7 @@
   <rect width="1080" height="526" class="fill-ffffff" />
 
   
-  <text x="60" y="60" class="subtitle">Figure 1 · Codec-Style Patch Selection</text>
+  <text x="60" y="60" class="subtitle">Codec-Style Patch Selection</text>
   <text x="60" y="98" class="title">Same 54-token budget. 3× the temporal range.</text>
   <text x="60" y="128" class="panel-sub">Standard pipelines spend their budget on a few dense frames. We keep <tspan font-weight="700" class="fill-2563eb">I-frames dense</tspan> and skim <tspan font-weight="700" class="fill-f59e0b">motion-rich patches</tspan> from P-frames instead.</text>
 

--- a/asset/method_codec_selection_light.svg
+++ b/asset/method_codec_selection_light.svg
@@ -31,7 +31,7 @@
   <rect width="1080" height="526" class="fill-ffffff" />
 
   
-  <text x="60" y="60" class="subtitle">Figure 1 · Codec-Style Patch Selection</text>
+  <text x="60" y="60" class="subtitle">Codec-Style Patch Selection</text>
   <text x="60" y="98" class="title">Same 54-token budget. 3× the temporal range.</text>
   <text x="60" y="128" class="panel-sub">Standard pipelines spend their budget on a few dense frames. We keep <tspan font-weight="700" class="fill-2563eb">I-frames dense</tspan> and skim <tspan font-weight="700" class="fill-f59e0b">motion-rich patches</tspan> from P-frames instead.</text>
 

--- a/asset/method_codec_vs_frame_dark.svg
+++ b/asset/method_codec_vs_frame_dark.svg
@@ -29,7 +29,7 @@ g[id^="cvf-panel-"]{animation:cvf-fade .4s ease-out both}
 </defs>
 <rect width="1100" height="580" class="fill-ffffff" />
 
-<line x1="36" y1="323" x2="1036" y2="323" stroke-width="0.6" class="stroke-eaecef" /><line x1="266" y1="75" x2="266" y2="550" stroke-width="0.6" class="stroke-eaecef" /><line x1="536" y1="75" x2="536" y2="550" stroke-width="0.6" class="stroke-eaecef" /><line x1="806" y1="75" x2="806" y2="550" stroke-width="0.6" class="stroke-eaecef" /><text class="caption" x="30" y="30"><tspan class="caption-muted">Figure 4: </tspan>Codec-aligned sampling vs. uniform frame sampling.</text>
+<line x1="36" y1="323" x2="1036" y2="323" stroke-width="0.6" class="stroke-eaecef" /><line x1="266" y1="75" x2="266" y2="550" stroke-width="0.6" class="stroke-eaecef" /><line x1="536" y1="75" x2="536" y2="550" stroke-width="0.6" class="stroke-eaecef" /><line x1="806" y1="75" x2="806" y2="550" stroke-width="0.6" class="stroke-eaecef" /><text class="caption" x="30" y="30">Codec-aligned sampling vs. uniform frame sampling.</text>
 <g transform="translate(730, 26)">
 
 <line x1="0" y1="0" x2="30" y2="0" stroke-width="1.8" class="stroke-1a1a1a" />

--- a/asset/method_codec_vs_frame_light.svg
+++ b/asset/method_codec_vs_frame_light.svg
@@ -29,7 +29,7 @@ g[id^="cvf-panel-"]{animation:cvf-fade .4s ease-out both}
 </defs>
 <rect width="1100" height="580" class="fill-ffffff" />
 
-<line x1="36" y1="323" x2="1036" y2="323" stroke-width="0.6" class="stroke-eaecef" /><line x1="266" y1="75" x2="266" y2="550" stroke-width="0.6" class="stroke-eaecef" /><line x1="536" y1="75" x2="536" y2="550" stroke-width="0.6" class="stroke-eaecef" /><line x1="806" y1="75" x2="806" y2="550" stroke-width="0.6" class="stroke-eaecef" /><text class="caption" x="30" y="30"><tspan class="caption-muted">Figure 4: </tspan>Codec-aligned sampling vs. uniform frame sampling.</text>
+<line x1="36" y1="323" x2="1036" y2="323" stroke-width="0.6" class="stroke-eaecef" /><line x1="266" y1="75" x2="266" y2="550" stroke-width="0.6" class="stroke-eaecef" /><line x1="536" y1="75" x2="536" y2="550" stroke-width="0.6" class="stroke-eaecef" /><line x1="806" y1="75" x2="806" y2="550" stroke-width="0.6" class="stroke-eaecef" /><text class="caption" x="30" y="30">Codec-aligned sampling vs. uniform frame sampling.</text>
 <g transform="translate(730, 26)">
 
 <line x1="0" y1="0" x2="30" y2="0" stroke-width="1.8" class="stroke-1a1a1a" />

--- a/asset/method_unified_encoder_dark.svg
+++ b/asset/method_unified_encoder_dark.svg
@@ -31,7 +31,7 @@
   </defs>
   <rect width="1080" height="820" class="fill-ffffff" />
 
-  <text x="60" y="44" class="subtitle">Figure 2 · One Encoder, Every Modality</text>
+  <text x="60" y="44" class="subtitle">One Encoder, Every Modality</text>
   <text x="60" y="80" class="title">OneVision-Encoder.</text>
   <text x="60" y="124" class="title">Three input types. Same token grid.</text>
   <text x="60" y="156" class="panel-sub">All three input types flow through the <tspan font-weight="700" class="fill-2563eb">same OneVision-Encoder</tspan> under shared <tspan font-weight="700" font-family="'SF Mono', 'Menlo', monospace" class="fill-0f172a">(t, h, w)</tspan> positions.</text>

--- a/asset/method_unified_encoder_light.svg
+++ b/asset/method_unified_encoder_light.svg
@@ -31,7 +31,7 @@
   </defs>
   <rect width="1080" height="820" class="fill-ffffff" />
 
-  <text x="60" y="44" class="subtitle">Figure 2 · One Encoder, Every Modality</text>
+  <text x="60" y="44" class="subtitle">One Encoder, Every Modality</text>
   <text x="60" y="80" class="title">OneVision-Encoder.</text>
   <text x="60" y="124" class="title">Three input types. Same token grid.</text>
   <text x="60" y="156" class="panel-sub">All three input types flow through the <tspan font-weight="700" class="fill-2563eb">same OneVision-Encoder</tspan> under shared <tspan font-weight="700" font-family="'SF Mono', 'Menlo', monospace" class="fill-0f172a">(t, h, w)</tspan> positions.</text>

--- a/offline_packing/s1_split_json_to_samples.py
+++ b/offline_packing/s1_split_json_to_samples.py
@@ -51,6 +51,10 @@ from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import Manager, Process, cpu_count
 from typing import Any, Optional
 
+# Pillow is only required when --jpeg-quality is enabled; import lazily inside the
+# conversion helper so the module remains importable in environments without PIL.
+_JPEG_RECODE_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".gif", ".webp", ".tiff", ".tif"}
+
 from tqdm import tqdm
 
 
@@ -105,6 +109,30 @@ def _resolve_image_path(path: str, base_dir: str, rel_img_path: Optional[str], i
     return os.path.normpath(os.path.join(base_dir, path))
 
 
+def _copy_or_recode_image(src_path: str, dst_path: str, jpeg_quality: int) -> str:
+    """Copy ``src_path`` to ``dst_path``; when ``jpeg_quality >= 0`` and the source
+    is a recodable raster image, re-encode as JPEG and return the actual dst path
+    (extension forced to ``.jpg``). Otherwise behaves like ``shutil.copy2``.
+    """
+    if jpeg_quality < 0:
+        shutil.copy2(src_path, dst_path)
+        return dst_path
+
+    src_ext = os.path.splitext(src_path)[1].lower()
+    if src_ext not in _JPEG_RECODE_EXTS:
+        shutil.copy2(src_path, dst_path)
+        return dst_path
+
+    from PIL import Image  # noqa: PLC0415 — lazy import; only needed when flag is on
+
+    new_dst = os.path.splitext(dst_path)[0] + ".jpg"
+    with Image.open(src_path) as im:
+        if im.mode != "RGB":
+            im = im.convert("RGB")
+        im.save(new_dst, format="JPEG", quality=int(jpeg_quality), optimize=False)
+    return new_dst
+
+
 def _process_single_item(args: tuple) -> Optional[str]:
     """
     Process a single data item: copy images, patch_position.npy files, and create JSON file.
@@ -116,7 +144,7 @@ def _process_single_item(args: tuple) -> Optional[str]:
     Returns:
         Output filename (without extension) or None if skipped
     """
-    (item, base_dir, output_dir, rel_img_path, image_root, no_img_indices, name_counter, name_lock) = args
+    (item, base_dir, output_dir, rel_img_path, image_root, no_img_indices, name_counter, name_lock, jpeg_quality) = args
 
     # Extract image paths from item
     original_image_paths: list[str] = []
@@ -172,13 +200,15 @@ def _process_single_item(args: tuple) -> Optional[str]:
     for idx, src_path in enumerate(resolved_paths):
         old_name = os.path.basename(src_path)
         new_name = _unique_filename(old_name, name_counter, name_lock)
-        new_image_basenames.append(new_name)
 
         dst_path = os.path.join(output_dir, new_name)
         try:
-            shutil.copy2(src_path, dst_path)
+            actual_dst = _copy_or_recode_image(src_path, dst_path, jpeg_quality)
+            if actual_dst != dst_path:
+                new_name = os.path.basename(actual_dst)
         except Exception as e:
             logger.error(f"Failed to copy image: {src_path} -> {dst_path} | {e}")
+        new_image_basenames.append(new_name)
 
         # Copy corresponding .npy file
         # First, check if explicit path was provided in the input JSON
@@ -253,6 +283,7 @@ def _worker_process(
     no_img_indices: list[int],
     name_counter,
     name_lock,
+    jpeg_quality: int,
 ) -> None:
     """
     Worker process that processes chunks of data items.
@@ -279,7 +310,7 @@ def _worker_process(
 
         # Build argument list for thread pool
         arg_list = [
-            (item, base_dir, output_dir, rel_img_path, image_root, no_img_indices, name_counter, name_lock)
+            (item, base_dir, output_dir, rel_img_path, image_root, no_img_indices, name_counter, name_lock, jpeg_quality)
             for item in chunk
         ]
 
@@ -303,6 +334,7 @@ def split_json_to_samples(
     chunk_size: int = 1000,
     num_threads: int = 8,
     shuffle: bool = True,
+    jpeg_quality: int = -1,
 ) -> set[str]:
     """
     Split a JSON array or JSONL file into individual sample files.
@@ -398,6 +430,7 @@ def split_json_to_samples(
                     no_img_indices,
                     name_counter,
                     name_lock,
+                    jpeg_quality,
                 ),
             )
             for _ in range(num_processes)
@@ -451,6 +484,13 @@ Examples:
     parser.add_argument("-m", "--num-threads", type=int, default=8, help="Number of threads per process (default: 8)")
     parser.add_argument("--no-shuffle", action="store_true", help="Do not shuffle data before processing")
     parser.add_argument(
+        "--jpeg-quality",
+        type=int,
+        default=-1,
+        help="If >=0, re-encode raster images as JPEG with the given quality (e.g. 80). "
+             "Output extension is forced to .jpg. Default -1 (disabled, byte-copy).",
+    )
+    parser.add_argument(
         "--log-level",
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
@@ -472,6 +512,7 @@ Examples:
         chunk_size=args.chunk_size,
         num_threads=args.num_threads,
         shuffle=not args.no_shuffle,
+        jpeg_quality=args.jpeg_quality,
     )
 
     # Print summary

--- a/tools/convert_checkpoint/config/llava-onevision2-2b/adapter.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-2b/adapter.json
@@ -1,8 +1,8 @@
 {
-    "adapter.layernorm.weight": "visual.merger.ln_q.weight",
-    "adapter.layernorm.bias": "visual.merger.ln_q.bias",
-    "adapter.linear_fc1.weight": "visual.merger.mlp.0.weight",
-    "adapter.linear_fc1.bias": "visual.merger.mlp.0.bias",
-    "adapter.linear_fc2.weight": "visual.merger.mlp.2.weight",
-    "adapter.linear_fc2.bias": "visual.merger.mlp.2.bias"
+    "adapter.layernorm.weight": "model.visual.merger.ln_q.weight",
+    "adapter.layernorm.bias": "model.visual.merger.ln_q.bias",
+    "adapter.linear_fc1.weight": "model.visual.merger.mlp.0.weight",
+    "adapter.linear_fc1.bias": "model.visual.merger.mlp.0.bias",
+    "adapter.linear_fc2.weight": "model.visual.merger.mlp.2.weight",
+    "adapter.linear_fc2.bias": "model.visual.merger.mlp.2.bias"
 }

--- a/tools/convert_checkpoint/config/llava-onevision2-2b/qwen3.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-2b/qwen3.json
@@ -52,8 +52,8 @@
     },
     "name_map": {
         "huggingface": {
-            "word_embeddings": "model.embed_tokens",
-            "transformer": "model",
+            "word_embeddings": "model.language_model.embed_tokens",
+            "transformer": "model.language_model",
             "layer_prefix": "layers",
             "input_layernorm": "input_layernorm",
             "attention.query_key_value": [
@@ -72,7 +72,7 @@
                 "mlp.up_proj"
             ],
             "mlp.dense_4h_to_h": "mlp.down_proj",
-            "final_layernorm": "model.norm",
+            "final_layernorm": "model.language_model.norm",
             "word_embeddings_for_head": "lm_head"
         },
         "mcore": {

--- a/tools/convert_checkpoint/config/llava-onevision2-2b/vision-model.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-2b/vision-model.json
@@ -31,7 +31,7 @@
     },
     "name_map": {
         "huggingface": {
-            "transformer": "visual",
+            "transformer": "model.visual",
             "layer_prefix": "encoder.layers",
             "input_layernorm": "layer_norm1",
             "attention.query_key_value": "self_attn.qkv",

--- a/tools/convert_checkpoint/config/llava-onevision2-2b/vision-patch.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-2b/vision-patch.json
@@ -1,5 +1,5 @@
 {
-    "vision_model.patch_embed.proj.weight": "visual.embeddings.patch_embedding.weight",
-    "vision_model.pre_layernorm.weight": "visual.layernorm_pre.weight",
-    "vision_model.pre_layernorm.bias": "visual.layernorm_pre.bias"
+    "vision_model.patch_embed.proj.weight": "model.visual.embeddings.patch_embedding.weight",
+    "vision_model.pre_layernorm.weight": "model.visual.layernorm_pre.weight",
+    "vision_model.pre_layernorm.bias": "model.visual.layernorm_pre.bias"
 }

--- a/tools/convert_checkpoint/config/llava-onevision2-30b-a3b/adapter.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-30b-a3b/adapter.json
@@ -1,8 +1,8 @@
 {
-    "adapter.layernorm.weight": "visual.merger.ln_q.weight",
-    "adapter.layernorm.bias": "visual.merger.ln_q.bias",
-    "adapter.linear_fc1.weight": "visual.merger.mlp.0.weight",
-    "adapter.linear_fc1.bias": "visual.merger.mlp.0.bias",
-    "adapter.linear_fc2.weight": "visual.merger.mlp.2.weight",
-    "adapter.linear_fc2.bias": "visual.merger.mlp.2.bias"
+    "adapter.layernorm.weight": "model.visual.merger.ln_q.weight",
+    "adapter.layernorm.bias": "model.visual.merger.ln_q.bias",
+    "adapter.linear_fc1.weight": "model.visual.merger.mlp.0.weight",
+    "adapter.linear_fc1.bias": "model.visual.merger.mlp.0.bias",
+    "adapter.linear_fc2.weight": "model.visual.merger.mlp.2.weight",
+    "adapter.linear_fc2.bias": "model.visual.merger.mlp.2.bias"
 }

--- a/tools/convert_checkpoint/config/llava-onevision2-30b-a3b/qwen3.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-30b-a3b/qwen3.json
@@ -60,8 +60,8 @@
     },
     "name_map": {
         "huggingface": {
-            "word_embeddings": "model.embed_tokens",
-            "transformer": "model",
+            "word_embeddings": "model.language_model.embed_tokens",
+            "transformer": "model.language_model",
             "layer_prefix": "layers",
             "input_layernorm": "input_layernorm",
             "attention.query_key_value": [
@@ -82,7 +82,7 @@
                 "up_proj"
             ],
             "mlp.dense_4h_to_h": "down_proj",
-            "final_layernorm": "model.norm",
+            "final_layernorm": "model.language_model.norm",
             "word_embeddings_for_head": "lm_head"
         },
         "mcore": {

--- a/tools/convert_checkpoint/config/llava-onevision2-30b-a3b/vision-model.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-30b-a3b/vision-model.json
@@ -31,7 +31,7 @@
     },
     "name_map": {
         "huggingface": {
-            "transformer": "visual",
+            "transformer": "model.visual",
             "layer_prefix": "encoder.layers",
             "input_layernorm": "layer_norm1",
             "attention.query_key_value": "self_attn.qkv",

--- a/tools/convert_checkpoint/config/llava-onevision2-30b-a3b/vision-patch.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-30b-a3b/vision-patch.json
@@ -1,5 +1,5 @@
 {
-    "vision_model.patch_embed.proj.weight": "visual.embeddings.patch_embedding.weight",
-    "vision_model.pre_layernorm.weight": "visual.layernorm_pre.weight",
-    "vision_model.pre_layernorm.bias": "visual.layernorm_pre.bias"
+    "vision_model.patch_embed.proj.weight": "model.visual.embeddings.patch_embedding.weight",
+    "vision_model.pre_layernorm.weight": "model.visual.layernorm_pre.weight",
+    "vision_model.pre_layernorm.bias": "model.visual.layernorm_pre.bias"
 }

--- a/tools/convert_checkpoint/config/llava-onevision2-4b-p16m2/adapter.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-4b-p16m2/adapter.json
@@ -1,8 +1,8 @@
 {
-    "adapter.layernorm.weight": "visual.merger.ln_q.weight",
-    "adapter.layernorm.bias": "visual.merger.ln_q.bias",
-    "adapter.linear_fc1.weight": "visual.merger.mlp.0.weight",
-    "adapter.linear_fc1.bias": "visual.merger.mlp.0.bias",
-    "adapter.linear_fc2.weight": "visual.merger.mlp.2.weight",
-    "adapter.linear_fc2.bias": "visual.merger.mlp.2.bias"
+    "adapter.layernorm.weight": "model.visual.merger.ln_q.weight",
+    "adapter.layernorm.bias": "model.visual.merger.ln_q.bias",
+    "adapter.linear_fc1.weight": "model.visual.merger.mlp.0.weight",
+    "adapter.linear_fc1.bias": "model.visual.merger.mlp.0.bias",
+    "adapter.linear_fc2.weight": "model.visual.merger.mlp.2.weight",
+    "adapter.linear_fc2.bias": "model.visual.merger.mlp.2.bias"
 }

--- a/tools/convert_checkpoint/config/llava-onevision2-4b-p16m2/qwen3.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-4b-p16m2/qwen3.json
@@ -52,8 +52,8 @@
     },
     "name_map": {
         "huggingface": {
-            "word_embeddings": "model.embed_tokens",
-            "transformer": "model",
+            "word_embeddings": "model.language_model.embed_tokens",
+            "transformer": "model.language_model",
             "layer_prefix": "layers",
             "input_layernorm": "input_layernorm",
             "attention.query_key_value": [
@@ -72,7 +72,7 @@
                 "mlp.up_proj"
             ],
             "mlp.dense_4h_to_h": "mlp.down_proj",
-            "final_layernorm": "model.norm",
+            "final_layernorm": "model.language_model.norm",
             "word_embeddings_for_head": "lm_head"
         },
         "mcore": {

--- a/tools/convert_checkpoint/config/llava-onevision2-4b-p16m2/vision-model.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-4b-p16m2/vision-model.json
@@ -31,7 +31,7 @@
     },
     "name_map": {
         "huggingface": {
-            "transformer": "visual",
+            "transformer": "model.visual",
             "layer_prefix": "encoder.layers",
             "input_layernorm": "layer_norm1",
             "attention.query_key_value": "self_attn.qkv",

--- a/tools/convert_checkpoint/config/llava-onevision2-4b-p16m2/vision-patch.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-4b-p16m2/vision-patch.json
@@ -1,5 +1,5 @@
 {
-    "vision_model.patch_embed.proj.weight": "visual.embeddings.patch_embedding.weight",
-    "vision_model.pre_layernorm.weight": "visual.layernorm_pre.weight",
-    "vision_model.pre_layernorm.bias": "visual.layernorm_pre.bias"
+    "vision_model.patch_embed.proj.weight": "model.visual.embeddings.patch_embedding.weight",
+    "vision_model.pre_layernorm.weight": "model.visual.layernorm_pre.weight",
+    "vision_model.pre_layernorm.bias": "model.visual.layernorm_pre.bias"
 }

--- a/tools/convert_checkpoint/config/llava-onevision2-4b-p16m3/adapter.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-4b-p16m3/adapter.json
@@ -1,8 +1,8 @@
 {
-    "adapter.layernorm.weight": "visual.merger.ln_q.weight",
-    "adapter.layernorm.bias": "visual.merger.ln_q.bias",
-    "adapter.linear_fc1.weight": "visual.merger.mlp.0.weight",
-    "adapter.linear_fc1.bias": "visual.merger.mlp.0.bias",
-    "adapter.linear_fc2.weight": "visual.merger.mlp.2.weight",
-    "adapter.linear_fc2.bias": "visual.merger.mlp.2.bias"
+    "adapter.layernorm.weight": "model.visual.merger.ln_q.weight",
+    "adapter.layernorm.bias": "model.visual.merger.ln_q.bias",
+    "adapter.linear_fc1.weight": "model.visual.merger.mlp.0.weight",
+    "adapter.linear_fc1.bias": "model.visual.merger.mlp.0.bias",
+    "adapter.linear_fc2.weight": "model.visual.merger.mlp.2.weight",
+    "adapter.linear_fc2.bias": "model.visual.merger.mlp.2.bias"
 }

--- a/tools/convert_checkpoint/config/llava-onevision2-4b-p16m3/qwen3.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-4b-p16m3/qwen3.json
@@ -52,8 +52,8 @@
     },
     "name_map": {
         "huggingface": {
-            "word_embeddings": "model.embed_tokens",
-            "transformer": "model",
+            "word_embeddings": "model.language_model.embed_tokens",
+            "transformer": "model.language_model",
             "layer_prefix": "layers",
             "input_layernorm": "input_layernorm",
             "attention.query_key_value": [
@@ -72,7 +72,7 @@
                 "mlp.up_proj"
             ],
             "mlp.dense_4h_to_h": "mlp.down_proj",
-            "final_layernorm": "model.norm",
+            "final_layernorm": "model.language_model.norm",
             "word_embeddings_for_head": "lm_head"
         },
         "mcore": {

--- a/tools/convert_checkpoint/config/llava-onevision2-4b-p16m3/vision-model.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-4b-p16m3/vision-model.json
@@ -31,7 +31,7 @@
     },
     "name_map": {
         "huggingface": {
-            "transformer": "visual",
+            "transformer": "model.visual",
             "layer_prefix": "encoder.layers",
             "input_layernorm": "layer_norm1",
             "attention.query_key_value": "self_attn.qkv",

--- a/tools/convert_checkpoint/config/llava-onevision2-4b-p16m3/vision-patch.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-4b-p16m3/vision-patch.json
@@ -1,5 +1,5 @@
 {
-    "vision_model.patch_embed.proj.weight": "visual.embeddings.patch_embedding.weight",
-    "vision_model.pre_layernorm.weight": "visual.layernorm_pre.weight",
-    "vision_model.pre_layernorm.bias": "visual.layernorm_pre.bias"
+    "vision_model.patch_embed.proj.weight": "model.visual.embeddings.patch_embedding.weight",
+    "vision_model.pre_layernorm.weight": "model.visual.layernorm_pre.weight",
+    "vision_model.pre_layernorm.bias": "model.visual.layernorm_pre.bias"
 }

--- a/tools/convert_checkpoint/config/llava-onevision2-4b/adapter.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-4b/adapter.json
@@ -1,8 +1,8 @@
 {
-    "adapter.layernorm.weight": "visual.merger.ln_q.weight",
-    "adapter.layernorm.bias": "visual.merger.ln_q.bias",
-    "adapter.linear_fc1.weight": "visual.merger.mlp.0.weight",
-    "adapter.linear_fc1.bias": "visual.merger.mlp.0.bias",
-    "adapter.linear_fc2.weight": "visual.merger.mlp.2.weight",
-    "adapter.linear_fc2.bias": "visual.merger.mlp.2.bias"
+    "adapter.layernorm.weight": "model.visual.merger.ln_q.weight",
+    "adapter.layernorm.bias": "model.visual.merger.ln_q.bias",
+    "adapter.linear_fc1.weight": "model.visual.merger.mlp.0.weight",
+    "adapter.linear_fc1.bias": "model.visual.merger.mlp.0.bias",
+    "adapter.linear_fc2.weight": "model.visual.merger.mlp.2.weight",
+    "adapter.linear_fc2.bias": "model.visual.merger.mlp.2.bias"
 }

--- a/tools/convert_checkpoint/config/llava-onevision2-4b/qwen3.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-4b/qwen3.json
@@ -52,8 +52,8 @@
     },
     "name_map": {
         "huggingface": {
-            "word_embeddings": "model.embed_tokens",
-            "transformer": "model",
+            "word_embeddings": "model.language_model.embed_tokens",
+            "transformer": "model.language_model",
             "layer_prefix": "layers",
             "input_layernorm": "input_layernorm",
             "attention.query_key_value": [
@@ -72,7 +72,7 @@
                 "mlp.up_proj"
             ],
             "mlp.dense_4h_to_h": "mlp.down_proj",
-            "final_layernorm": "model.norm",
+            "final_layernorm": "model.language_model.norm",
             "word_embeddings_for_head": "lm_head"
         },
         "mcore": {

--- a/tools/convert_checkpoint/config/llava-onevision2-4b/vision-model.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-4b/vision-model.json
@@ -31,7 +31,7 @@
     },
     "name_map": {
         "huggingface": {
-            "transformer": "visual",
+            "transformer": "model.visual",
             "layer_prefix": "encoder.layers",
             "input_layernorm": "layer_norm1",
             "attention.query_key_value": "self_attn.qkv",

--- a/tools/convert_checkpoint/config/llava-onevision2-4b/vision-patch.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-4b/vision-patch.json
@@ -1,5 +1,5 @@
 {
-    "vision_model.patch_embed.proj.weight": "visual.embeddings.patch_embedding.weight",
-    "vision_model.pre_layernorm.weight": "visual.layernorm_pre.weight",
-    "vision_model.pre_layernorm.bias": "visual.layernorm_pre.bias"
+    "vision_model.patch_embed.proj.weight": "model.visual.embeddings.patch_embedding.weight",
+    "vision_model.pre_layernorm.weight": "model.visual.layernorm_pre.weight",
+    "vision_model.pre_layernorm.bias": "model.visual.layernorm_pre.bias"
 }

--- a/tools/convert_checkpoint/config/llava-onevision2-8b/adapter.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-8b/adapter.json
@@ -1,8 +1,8 @@
 {
-    "adapter.layernorm.weight": "visual.merger.ln_q.weight",
-    "adapter.layernorm.bias": "visual.merger.ln_q.bias",
-    "adapter.linear_fc1.weight": "visual.merger.mlp.0.weight",
-    "adapter.linear_fc1.bias": "visual.merger.mlp.0.bias",
-    "adapter.linear_fc2.weight": "visual.merger.mlp.2.weight",
-    "adapter.linear_fc2.bias": "visual.merger.mlp.2.bias"
+    "adapter.layernorm.weight": "model.visual.merger.ln_q.weight",
+    "adapter.layernorm.bias": "model.visual.merger.ln_q.bias",
+    "adapter.linear_fc1.weight": "model.visual.merger.mlp.0.weight",
+    "adapter.linear_fc1.bias": "model.visual.merger.mlp.0.bias",
+    "adapter.linear_fc2.weight": "model.visual.merger.mlp.2.weight",
+    "adapter.linear_fc2.bias": "model.visual.merger.mlp.2.bias"
 }

--- a/tools/convert_checkpoint/config/llava-onevision2-8b/qwen3.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-8b/qwen3.json
@@ -52,8 +52,8 @@
     },
     "name_map": {
         "huggingface": {
-            "word_embeddings": "model.embed_tokens",
-            "transformer": "model",
+            "word_embeddings": "model.language_model.embed_tokens",
+            "transformer": "model.language_model",
             "layer_prefix": "layers",
             "input_layernorm": "input_layernorm",
             "attention.query_key_value": [
@@ -72,7 +72,7 @@
                 "mlp.up_proj"
             ],
             "mlp.dense_4h_to_h": "mlp.down_proj",
-            "final_layernorm": "model.norm",
+            "final_layernorm": "model.language_model.norm",
             "word_embeddings_for_head": "lm_head"
         },
         "mcore": {

--- a/tools/convert_checkpoint/config/llava-onevision2-8b/vision-model.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-8b/vision-model.json
@@ -31,7 +31,7 @@
     },
     "name_map": {
         "huggingface": {
-            "transformer": "visual",
+            "transformer": "model.visual",
             "layer_prefix": "encoder.layers",
             "input_layernorm": "layer_norm1",
             "attention.query_key_value": "self_attn.qkv",

--- a/tools/convert_checkpoint/config/llava-onevision2-8b/vision-patch.json
+++ b/tools/convert_checkpoint/config/llava-onevision2-8b/vision-patch.json
@@ -1,5 +1,5 @@
 {
-    "vision_model.patch_embed.proj.weight": "visual.embeddings.patch_embedding.weight",
-    "vision_model.pre_layernorm.weight": "visual.layernorm_pre.weight",
-    "vision_model.pre_layernorm.bias": "visual.layernorm_pre.bias"
+    "vision_model.patch_embed.proj.weight": "model.visual.embeddings.patch_embedding.weight",
+    "vision_model.pre_layernorm.weight": "model.visual.layernorm_pre.weight",
+    "vision_model.pre_layernorm.bias": "model.visual.layernorm_pre.bias"
 }


### PR DESCRIPTION
## Summary

- **docs**: remove figure numbering (`Figure N ·`) from method SVGs and sync README alt text
- **fix**: tie dummy grad for text-only packed samples when vision modules are frozen, preventing NCCL desync during backward
- **fix**: update all `llava-onevision2-*` checkpoint conversion configs to use `model.visual.*` / `model.language_model.*` HF weight paths matching the composite `LlavaOnevision2ForConditionalGeneration` layout (2b, 4b, 4b-p16m2, 4b-p16m3, 8b, 30b-a3b)
- **feat**: add optional `--jpeg-quality` JPEG re-encoding to offline packing image splitter