### PR TITLE
feat: accept hf hub repo ids in merge_ov2 cli paths

### DIFF
--- a/transformers_impl/merge_ov2/cli.py
+++ b/transformers_impl/merge_ov2/cli.py
@@ -1,11 +1,12 @@
 import argparse
+import os
 import sys
 
 import torch
 
 from transformers import logging
 
-from .loader import load_all_weights
+from .loader import _resolve_local_or_hub, load_all_weights
 from .save import save_merged
 from .utils import log_stage
 from .variants import get_variant
@@ -43,6 +44,25 @@ def _resolve_strategies(args: argparse.Namespace) -> None:
     # the production processor that ships with the saved checkpoint.
     if getattr(args, "qwen_processor_path", None) is None and getattr(args, "processor_path", None):
         args.qwen_processor_path = args.processor_path
+
+
+# Path attrs that may be HF Hub repo IDs; resolved at CLI entry so downstream
+# code stays Hub-agnostic. Add new path attrs here when adding new subcommands.
+_HUB_RESOLVABLE_PATH_ATTRS: tuple[str, ...] = (
+    "vit_path",
+    "llm_path",
+    "processor_path",
+    "qwen_processor_path",
+    "ckpt_path",
+    "adapter_path",
+)
+
+
+def _resolve_paths(args: argparse.Namespace) -> None:
+    for attr in _HUB_RESOLVABLE_PATH_ATTRS:
+        val = getattr(args, attr, None)
+        if val and not os.path.exists(val):
+            setattr(args, attr, _resolve_local_or_hub(val))
 
 
 def _reject_unsafe_combos(args: argparse.Namespace) -> None:
@@ -109,6 +129,7 @@ _DTYPE = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}
 
 def _cmd_merge(args: argparse.Namespace) -> int:
     _resolve_strategies(args)
+    _resolve_paths(args)
     _reject_unsafe_combos(args)
     _enforce_validation_required(args, need_e2e=True)
 
@@ -161,6 +182,7 @@ def _cmd_merge(args: argparse.Namespace) -> int:
 
 def _cmd_validate(args: argparse.Namespace) -> int:
     _resolve_strategies(args)
+    _resolve_paths(args)
     _reject_unsafe_combos(args)
     _enforce_validation_required(args, need_e2e=True)
 
@@ -202,6 +224,7 @@ def _cmd_validate(args: argparse.Namespace) -> int:
 def _cmd_dry_run(args: argparse.Namespace) -> int:
     from .loader import dry_run_report
 
+    _resolve_paths(args)
     variant = get_variant(args.variant)
     with log_stage("build_empty"):
         model, _processor, _tokenizer = variant.build_empty(

--- a/transformers_impl/merge_ov2/cli.py
+++ b/transformers_impl/merge_ov2/cli.py
@@ -57,12 +57,18 @@ _HUB_RESOLVABLE_PATH_ATTRS: tuple[str, ...] = (
     "adapter_path",
 )
 
+# Subset of the above whose Hub source is consumed only by AutoProcessor /
+# AutoTokenizer / CLIPImageProcessor.from_pretrained — no model weights needed.
+# Routed to _resolve_local_or_hub(kind="processor") to skip multi-GB safetensors.
+_HUB_PROCESSOR_PATH_ATTRS: frozenset[str] = frozenset({"processor_path", "qwen_processor_path"})
+
 
 def _resolve_paths(args: argparse.Namespace) -> None:
     for attr in _HUB_RESOLVABLE_PATH_ATTRS:
         val = getattr(args, attr, None)
         if val and not os.path.exists(val):
-            setattr(args, attr, _resolve_local_or_hub(val))
+            kind = "processor" if attr in _HUB_PROCESSOR_PATH_ATTRS else "model"
+            setattr(args, attr, _resolve_local_or_hub(val, kind=kind))
 
 
 def _reject_unsafe_combos(args: argparse.Namespace) -> None:

--- a/transformers_impl/merge_ov2/loader.py
+++ b/transformers_impl/merge_ov2/loader.py
@@ -32,10 +32,29 @@ class LoadReport:
         )
 
 
+# Skip legacy weight formats and binary pickles to keep cache lean. We still
+# pull config.json, modeling_*.py, preprocessor_config.json and tokenizer files
+# because dense.py / moe.py read the ViT config and validators reload via
+# AutoModel(trust_remote_code=True) / AutoTokenizer / CLIPImageProcessor — all
+# of which need the full repo layout, not just *.safetensors.
+_HUB_IGNORE_PATTERNS: tuple[str, ...] = (
+    "*.bin",
+    "*.h5",
+    "*.msgpack",
+    "*.onnx",
+    "*.gguf",
+    "*.pt",
+    "*.pth",
+    "*.pkl",
+    "*.tflite",
+    "*.ot",
+)
+
+
 def _resolve_local_or_hub(path: str) -> str:
     if os.path.exists(path):
         return path
-    return snapshot_download(path, allow_patterns="*.safetensors")
+    return snapshot_download(path, ignore_patterns=list(_HUB_IGNORE_PATTERNS))
 
 
 def apply_weights(

--- a/transformers_impl/merge_ov2/loader.py
+++ b/transformers_impl/merge_ov2/loader.py
@@ -32,12 +32,12 @@ class LoadReport:
         )
 
 
-# Skip legacy weight formats and binary pickles to keep cache lean. We still
-# pull config.json, modeling_*.py, preprocessor_config.json and tokenizer files
-# because dense.py / moe.py read the ViT config and validators reload via
-# AutoModel(trust_remote_code=True) / AutoTokenizer / CLIPImageProcessor — all
-# of which need the full repo layout, not just *.safetensors.
-_HUB_IGNORE_PATTERNS: tuple[str, ...] = (
+# Model paths (vit/llm/adapter/ckpt): pull the full repo minus legacy weight
+# formats. We still need config.json, modeling_*.py, preprocessor_config.json,
+# tokenizer files and *.safetensors because dense.py / moe.py read the ViT
+# config and validators reload via AutoModel(trust_remote_code=True) /
+# AutoTokenizer / CLIPImageProcessor — all of which need the full repo layout.
+_HUB_MODEL_IGNORE_PATTERNS: tuple[str, ...] = (
     "*.bin",
     "*.h5",
     "*.msgpack",
@@ -50,11 +50,37 @@ _HUB_IGNORE_PATTERNS: tuple[str, ...] = (
     "*.ot",
 )
 
+# Processor paths (processor/qwen_processor): the consumers are
+# AutoProcessor / AutoTokenizer / CLIPImageProcessor.from_pretrained — they
+# only need tokenizer + processor + image_processor configs (KB-scale). Many
+# repos used as a processor source (e.g. lmms-lab/LLaVA-OneVision-1.5-*) are
+# full N-billion-param model repos with ~16GB of safetensors we never read.
+# Whitelist exactly the file shapes the *_from_pretrained loaders need.
+_HUB_PROCESSOR_ALLOW_PATTERNS: tuple[str, ...] = (
+    "*.json",
+    "*.txt",
+    "*.model",
+    "*.jinja",
+    "tokenizer*",
+    "processor_config*",
+    "preprocessor_config*",
+    "tokenization_*.py",
+    "processing_*.py",
+    "image_processing_*.py",
+    "video_processing_*.py",
+    "feature_extraction_*.py",
+)
 
-def _resolve_local_or_hub(path: str) -> str:
+
+def _resolve_local_or_hub(path: str, *, kind: str = "model") -> str:
     if os.path.exists(path):
         return path
-    return snapshot_download(path, ignore_patterns=list(_HUB_IGNORE_PATTERNS))
+    if kind == "processor":
+        return snapshot_download(path, allow_patterns=list(_HUB_PROCESSOR_ALLOW_PATTERNS))
+    if kind != "model":
+        msg = f"unknown kind {kind!r}; expected 'model' or 'processor'"
+        raise ValueError(msg)
+    return snapshot_download(path, ignore_patterns=list(_HUB_MODEL_IGNORE_PATTERNS))
 
 
 def apply_weights(


### PR DESCRIPTION
## Summary

- Let `merge_ov2 merge|validate|dry-run` accept HF Hub repo IDs anywhere a local checkpoint path is expected (`--vit`, `--llm`, `--processor`, `--qwen-processor`, `--ckpt`, `--adapter`). Repo IDs are resolved to a snapshot dir at CLI entry, so users no longer need to pre-download the encoder/LLM/processor manually.
- Route processor-only paths through a separate `snapshot_download(allow_patterns=...)` call that whitelists exactly the file shapes `Qwen2Tokenizer.from_pretrained` / `AutoProcessor.from_pretrained` / `CLIPImageProcessor.from_pretrained` actually read, so passing a model repo as a processor source no longer drags in multi-GB safetensors that nothing in the pipeline opens.

## Motivation

Today even a one-shot smoke test forces the user to pre-fetch three repos (encoder, LLM, processor source) and feed local paths to the CLI. We want to type the repo ID directly:

```bash
python -m transformers_impl.merge_ov2.cli merge --variant 4b_p14m33 \
  --vit lmms-lab-encoder/onevision-encoder-large-lang-tf57 \
  --llm Qwen/Qwen3-4B-Instruct-2507 \
  --processor lmms-lab/LLaVA-OneVision-1.5-8B-Instruct \
  --output ./out
```

The naive implementation that was already sitting in `_resolve_local_or_hub` (`snapshot_download(path, allow_patterns="*.safetensors")`) was never actually reachable through the CLI and was broken on its own merits: variants probe `vit_path/config.json`, validators reload via `AutoModel(trust_remote_code=True)` / `AutoTokenizer` / `CLIPImageProcessor`, and a safetensors-only snapshot would silently miss every one of those files.

## Changes

### `feat: accept hf hub repo ids as merge_ov2 path arguments` (d77df34)

- Add `_resolve_paths(args)` in `cli.py` that walks `_HUB_RESOLVABLE_PATH_ATTRS` (`vit_path`, `llm_path`, `processor_path`, `qwen_processor_path`, `ckpt_path`, `adapter_path`) and, for any value that is not an existing local path, calls `_resolve_local_or_hub` to materialize a snapshot dir.
- Wire `_resolve_paths(args)` into `_cmd_merge`, `_cmd_validate`, `_cmd_dry_run` immediately after `_resolve_strategies` / before strict combo checks.
- Replace `snapshot_download(path, allow_patterns="*.safetensors")` with `snapshot_download(path, ignore_patterns=[...legacy weight formats only...])` so the snapshot contains `config.json`, `modeling_*.py`, `preprocessor_config.json`, tokenizer files and the `*.safetensors` shards together — which is what `dense.py` / `moe.py` / the validators expect.

### `perf: skip model weights when resolving processor hub repos` (5a54bdc)

- Split `_resolve_local_or_hub` into a `kind` switch:
  - `kind='model'` → `ignore_patterns` (full repo minus legacy weight formats), unchanged behavior for `vit/llm/adapter/ckpt`.
  - `kind='processor'` → `allow_patterns` whitelisting `*.json`, `*.txt`, `*.model`, `*.jinja`, `tokenizer*`, `processor_config*`, `preprocessor_config*`, `tokenization_*.py`, `processing_*.py`, `image_processing_*.py`, `video_processing_*.py`, `feature_extraction_*.py`.
- Route `processor_path` and `qwen_processor_path` through `kind='processor'` via a new `_HUB_PROCESSOR_PATH_ATTRS` frozenset in `cli._resolve_paths`. Future processor-only path attributes only need to be added to that frozenset.

Measured impact for `lmms-lab/LLaVA-OneVision-1.5-8B-Instruct` as a processor source: snapshot footprint drops from ~16 GB to ~16 MB; download finishes in seconds instead of minutes.

## Verification

- `ruff check` + `ruff check --select I` clean on both files.
- Dry run with three Hub repo IDs end-to-end (`--vit lmms-lab-encoder/onevision-encoder-large-lang-tf57`, `--llm Qwen/Qwen3-4B-Instruct-2507`, `--processor lmms-lab/LLaVA-OneVision-1.5-8B-Instruct`) — `[ViT] loaded=291 missing=0 shape_mismatch=0`, `[LLM] loaded=399 missing=0 shape_mismatch=0`, `uncovered_model_params=6` (expected non-tied params).
- Full `merge` with the same three Hub repo IDs and `--variant 4b_p14m33` on a single GPU:
  - `vit_layerwise` validator: 24/24 layers pass, min cosine similarity `0.99985349` (≥ 0.999 threshold).
  - `llm_parallel` and `e2e` validators pass.
  - Save: 9.0 GB safetensors, 1 shard, ~11 s.
  - Resulting checkpoint has 696 keys (297 visual + 398 text + 1 lm_head), `architectures=['LlavaOnevision2ForConditionalGeneration']`, vision (patch=14, hidden=1024, layers=24, sms=3), text (hidden=2560, layers=36), `patch_embedding [1024,3,14,14]`, `embed_tokens [151936,2560]`.
- Processor snapshot for `lmms-lab/LLaVA-OneVision-1.5-8B-Instruct` confirmed at 16 MB / 11 files (no `*.safetensors`).

## Risk

Local-path users see no behavioral change — `os.path.exists` short-circuits before any download. Hub-path users on the previous `*.safetensors`-only resolver were never functional (`config.json` / tokenizer / preprocessor missing), so there is no regression surface; the new behavior is the only one that ever actually worked.