### PR TITLE
fix(page): point Code resource to the official LLaVA-OneVision-2 repo

### DIFF
--- a/docs/page/index.html
+++ b/docs/page/index.html
@@ -2757,7 +2757,7 @@
                 <span class="i18n" data-lang="en">Code &amp; Demos</span><span class="i18n" data-lang="zh">代码与演示</span>
               </h3>
               <div class="resource-items">
-                 <a class="resource-item" href="https://github.com/anxiangsir/LLaVA-OneVision-2.0" target="_blank" rel="noopener noreferrer">
+                 <a class="resource-item" href="https://github.com/EvolvingLMMs-Lab/LLaVA-OneVision-2" target="_blank" rel="noopener noreferrer">
                    <div class="resource-top">LLaVA-OneVision-2 (GitHub)<span class="resource-badge">Code</span></div>
                   <div class="resource-meta"><span class="i18n" data-lang="en">Training code, configs, and evaluation harness.</span><span class="i18n" data-lang="zh">训练代码、配置文件与评测套件。</span></div>
                 </a>


### PR DESCRIPTION
Single-line fix: the 'Code & Demos' card on the project landing page (`docs/page/index.html`) was pointing to a personal-account fork (`anxiangsir/LLaVA-OneVision-2.0`). Re-targets to the canonical `EvolvingLMMs-Lab/LLaVA-OneVision-2` — the same repo that hosts this Pages site.

No other changes.