### PR TITLE
fix(page): point demo/models/datasets cards to HF collection

### DIFF
--- a/docs/page/index.html
+++ b/docs/page/index.html
@@ -2761,7 +2761,7 @@
                    <div class="resource-top">LLaVA-OneVision-2 (GitHub)<span class="resource-badge">Code</span></div>
                   <div class="resource-meta"><span class="i18n" data-lang="en">Training code, configs, and evaluation harness.</span><span class="i18n" data-lang="zh">训练代码、配置文件与评测套件。</span></div>
                 </a>
-                <a class="resource-item" href="#">
+                <a class="resource-item" href="https://huggingface.co/collections/mvp-lab/llava-onevision-2" target="_blank" rel="noopener noreferrer">
                   <div class="resource-top">Online Demo<span class="resource-badge">Space</span></div>
                   <div class="resource-meta"><span class="i18n" data-lang="en">HuggingFace Space for interactive demo.</span><span class="i18n" data-lang="zh">HuggingFace Space 在线演示。</span></div>
                 </a>
@@ -2772,7 +2772,7 @@
                 <span class="i18n" data-lang="en">Model Checkpoints</span><span class="i18n" data-lang="zh">模型权重</span>
               </h3>
               <div class="resource-items">
-                <a class="resource-item" href="#"><div class="resource-top">LLaVA-OneVision-2-8B<span class="resource-badge">HF</span></div><div class="resource-meta">TBD</div></a>
+                <a class="resource-item" href="https://huggingface.co/collections/mvp-lab/llava-onevision-2" target="_blank" rel="noopener noreferrer"><div class="resource-top">LLaVA-OneVision-2-8B<span class="resource-badge">HF</span></div><div class="resource-meta"><span class="i18n" data-lang="en">Pretrained checkpoints on HuggingFace.</span><span class="i18n" data-lang="zh">HuggingFace 上的预训练权重。</span></div></a>
               </div>
             </div>
             <div class="resource-group wide">
@@ -2780,7 +2780,7 @@
                 <span class="i18n" data-lang="en">Training Datasets</span><span class="i18n" data-lang="zh">训练数据集</span>
               </h3>
               <div class="resource-items">
-                 <a class="resource-item" href="https://huggingface.co/datasets/mvp-lab/LLaVA-OneVision-2-Data" target="_blank" rel="noopener noreferrer"><div class="resource-top">LLaVA-OneVision-2-Data<span class="resource-badge">Dataset</span></div><div class="resource-meta"><span class="i18n" data-lang="en">Pretraining + instruction data.</span><span class="i18n" data-lang="zh">预训练 + 指令数据。</span></div></a>
+                 <a class="resource-item" href="https://huggingface.co/collections/mvp-lab/llava-onevision-2" target="_blank" rel="noopener noreferrer"><div class="resource-top">LLaVA-OneVision-2-Data<span class="resource-badge">Dataset</span></div><div class="resource-meta"><span class="i18n" data-lang="en">Pretraining + instruction data.</span><span class="i18n" data-lang="zh">预训练 + 指令数据。</span></div></a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

The Open-Source Resources section on the homepage had three cards pointing to placeholders or a narrower URL:

- **Online Demo** \`href="#"\`
- **LLaVA-OneVision-2-8B** (Model Checkpoints) \`href="#"\` with meta \`TBD\`
- **LLaVA-OneVision-2-Data** (Training Datasets) pointed to one dataset only

All three now point to the canonical HuggingFace collection so visitors land on a unified hub of models + datasets.

## URL
https://huggingface.co/collections/mvp-lab/llava-onevision-2 (verified HTTP 200)

## Verification
- \`grep 'resource-item.*href="#"' docs/page/index.html\` → no matches
- Local diff: 3 lines changed, all in \`docs/page/index.html\`
