### PR TITLE
fix(page): wire hero buttons to real targets, drop Demo placeholder

### DIFF
--- a/docs/page/index.html
+++ b/docs/page/index.html
@@ -131,21 +131,17 @@
             全开放多模态训练的新一代——在配方透明度、原生分辨率理解和端到端可复现性方面持续突破。
           </p>
           <div class="link-row">
-            <a href="#" target="_blank" rel="noopener noreferrer">
+            <a href="https://github.com/EvolvingLMMs-Lab/LLaVA-OneVision-2" target="_blank" rel="noopener noreferrer">
               <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"></path></svg>
               <span class="i18n" data-lang="en">Code</span><span class="i18n" data-lang="zh">代码</span>
             </a>
-            <a href="#" target="_blank" rel="noopener noreferrer">
+            <a href="https://github.com/EvolvingLMMs-Lab/LLaVA-OneVision-2#citation" target="_blank" rel="noopener noreferrer">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
               <span class="i18n" data-lang="en">Technical Report</span><span class="i18n" data-lang="zh">技术报告</span>
             </a>
-            <a href="#" target="_blank" rel="noopener noreferrer">
+            <a href="https://huggingface.co/collections/mvp-lab/llava-onevision-2" target="_blank" rel="noopener noreferrer">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
               <span class="i18n" data-lang="en">Models &amp; Datasets</span><span class="i18n" data-lang="zh">模型与数据集</span>
-            </a>
-            <a href="#" target="_blank" rel="noopener noreferrer">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"></circle><polygon points="10 8 16 12 10 16 10 8"></polygon></svg>
-              <span class="i18n" data-lang="en">Demo</span><span class="i18n" data-lang="zh">演示</span>
             </a>
           </div>
         </header>


### PR DESCRIPTION
## Summary
The homepage hero (\`docs/page/index.html\`) had four placeholder buttons all pointing to \`href="#"\`. This PR replaces them with real targets and drops the unimplemented Demo button.

| Button | Before | After |
|---|---|---|
| Code | \`#\` | https://github.com/EvolvingLMMs-Lab/LLaVA-OneVision-2 |
| Technical Report | \`#\` | https://github.com/EvolvingLMMs-Lab/LLaVA-OneVision-2#citation |
| Models & Datasets | \`#\` | https://huggingface.co/collections/mvp-lab/llava-onevision-2 |
| Demo | \`#\` | _removed_ |

## Verification
- Diff: 3 insertions, 7 deletions in \`docs/page/index.html\`
- All retained URLs verified reachable
