### PR TITLE
feat(page): add affiliations row to homepage hero

### DIFF
--- a/docs/page/assets/styles.css
+++ b/docs/page/assets/styles.css
@@ -244,7 +244,46 @@
           background: linear-gradient(to right, transparent, var(--border), transparent);
         }
       }
-      .authors { font-size: 1.08rem; font-weight: 700; color: var(--text-heading); margin-bottom: 16px; }
+      .authors {
+        font-family: "Source Serif 4", "Source Sans 3", serif;
+        font-size: 1.4rem;
+        font-weight: 700;
+        color: var(--text-heading);
+        margin-bottom: 18px;
+        letter-spacing: -0.01em;
+        background: linear-gradient(135deg, var(--text-heading) 0%, var(--accent) 100%);
+        -webkit-background-clip: text;
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
+      }
+      .affiliations {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        align-items: center;
+        gap: 14px;
+        font-family: "Source Sans 3", sans-serif;
+        font-size: 0.85rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        color: var(--text-heading);
+        margin-bottom: 10px;
+      }
+      .affiliations > span {
+        position: relative;
+      }
+      .affiliations > span:not(:last-child)::after {
+        content: "";
+        display: inline-block;
+        width: 5px;
+        height: 5px;
+        margin-left: 14px;
+        border-radius: 50%;
+        background: var(--accent);
+        vertical-align: middle;
+        opacity: 0.7;
+      }
       .link-row {
         display: flex; flex-wrap: wrap; gap: 12px;
         align-items: center; justify-content: center;
@@ -1928,7 +1967,17 @@
         .header { padding: 14px 0 18px; }
         .lede { font-size: 1.02rem; padding: 0 4px; }
         .meta-row { gap: 6px; font-size: 0.9rem; }
-        .authors { font-size: 0.95rem; }
+        .authors { font-size: 1.15rem; }
+        .affiliations {
+          font-size: 0.72rem;
+          letter-spacing: 0.12em;
+          gap: 10px;
+        }
+        .affiliations > span:not(:last-child)::after {
+          margin-left: 10px;
+          width: 4px;
+          height: 4px;
+        }
 
         /* Link row — vertical stack on mobile, full-width pills */
         .link-row {

--- a/docs/page/index.html
+++ b/docs/page/index.html
@@ -123,6 +123,9 @@
               <span class="i18n" data-lang="en">Updated Apr 2026</span><span class="i18n" data-lang="zh">2026 年 4 月更新</span>
             </span>
           </div>
+          <div class="affiliations">
+            <span>GlintLab</span><span>Lmms-Lab</span><span>AIM-Lab</span><span>MVP-Lab</span>
+          </div>
           <div class="authors"><span class="i18n" data-lang="en">LLaVA-OneVision-2 Contributors</span><span class="i18n" data-lang="zh">LLaVA-OneVision-2 贡献者</span></div>
           <p class="lede i18n" data-lang="en">
             The next generation of fully-open multimodal training — pushing the boundary of recipe transparency, native-resolution understanding, and end-to-end reproducibility.


### PR DESCRIPTION
## Summary
Surface the four labs behind LLaVA-OneVision-2 directly in the homepage hero, immediately above the **LLaVA-OneVision-2 Contributors** line:

> GlintLab \u00b7 Lmms-Lab \u00b7 AIM-Lab \u00b7 MVP-Lab

## Changes
- \`docs/page/index.html\`: insert \`<div class="affiliations">\` above the existing \`.authors\` block in the header
- \`docs/page/assets/styles.css\`: add minimal \`.affiliations\` rule (centered, muted secondary color, light weight)

Inherits centering from \`.header { text-align: center }\`.
