### PR TITLE
feat(page): polish homepage hero and resource cards

### DIFF
--- a/docs/page/assets/styles.css
+++ b/docs/page/assets/styles.css
@@ -244,7 +244,46 @@
           background: linear-gradient(to right, transparent, var(--border), transparent);
         }
       }
-      .authors { font-size: 1.08rem; font-weight: 700; color: var(--text-heading); margin-bottom: 16px; }
+      .authors {
+        font-family: "Source Serif 4", "Source Sans 3", serif;
+        font-size: 1.4rem;
+        font-weight: 700;
+        color: var(--text-heading);
+        margin-bottom: 18px;
+        letter-spacing: -0.01em;
+        background: linear-gradient(135deg, var(--text-heading) 0%, var(--accent) 100%);
+        -webkit-background-clip: text;
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
+      }
+      .affiliations {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        align-items: center;
+        gap: 14px;
+        font-family: "Source Sans 3", sans-serif;
+        font-size: 0.85rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        color: var(--text-heading);
+        margin-bottom: 10px;
+      }
+      .affiliations > span {
+        position: relative;
+      }
+      .affiliations > span:not(:last-child)::after {
+        content: "";
+        display: inline-block;
+        width: 5px;
+        height: 5px;
+        margin-left: 14px;
+        border-radius: 50%;
+        background: var(--accent);
+        vertical-align: middle;
+        opacity: 0.7;
+      }
       .link-row {
         display: flex; flex-wrap: wrap; gap: 12px;
         align-items: center; justify-content: center;
@@ -1928,7 +1967,17 @@
         .header { padding: 14px 0 18px; }
         .lede { font-size: 1.02rem; padding: 0 4px; }
         .meta-row { gap: 6px; font-size: 0.9rem; }
-        .authors { font-size: 0.95rem; }
+        .authors { font-size: 1.15rem; }
+        .affiliations {
+          font-size: 0.72rem;
+          letter-spacing: 0.12em;
+          gap: 10px;
+        }
+        .affiliations > span:not(:last-child)::after {
+          margin-left: 10px;
+          width: 4px;
+          height: 4px;
+        }
 
         /* Link row — vertical stack on mobile, full-width pills */
         .link-row {

--- a/docs/page/index.html
+++ b/docs/page/index.html
@@ -123,6 +123,9 @@
               <span class="i18n" data-lang="en">Updated Apr 2026</span><span class="i18n" data-lang="zh">2026 年 4 月更新</span>
             </span>
           </div>
+          <div class="affiliations">
+            <span>GlintLab</span><span>Lmms-Lab</span><span>AIM-Lab</span><span>MVP-Lab</span>
+          </div>
           <div class="authors"><span class="i18n" data-lang="en">LLaVA-OneVision-2 Contributors</span><span class="i18n" data-lang="zh">LLaVA-OneVision-2 贡献者</span></div>
           <p class="lede i18n" data-lang="en">
             The next generation of fully-open multimodal training — pushing the boundary of recipe transparency, native-resolution understanding, and end-to-end reproducibility.
@@ -131,21 +134,17 @@
             全开放多模态训练的新一代——在配方透明度、原生分辨率理解和端到端可复现性方面持续突破。
           </p>
           <div class="link-row">
-            <a href="#" target="_blank" rel="noopener noreferrer">
+            <a href="https://github.com/EvolvingLMMs-Lab/LLaVA-OneVision-2" target="_blank" rel="noopener noreferrer">
               <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"></path></svg>
               <span class="i18n" data-lang="en">Code</span><span class="i18n" data-lang="zh">代码</span>
             </a>
-            <a href="#" target="_blank" rel="noopener noreferrer">
+            <a href="https://github.com/EvolvingLMMs-Lab/LLaVA-OneVision-2#citation" target="_blank" rel="noopener noreferrer">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
               <span class="i18n" data-lang="en">Technical Report</span><span class="i18n" data-lang="zh">技术报告</span>
             </a>
-            <a href="#" target="_blank" rel="noopener noreferrer">
+            <a href="https://huggingface.co/collections/mvp-lab/llava-onevision-2" target="_blank" rel="noopener noreferrer">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
               <span class="i18n" data-lang="en">Models &amp; Datasets</span><span class="i18n" data-lang="zh">模型与数据集</span>
-            </a>
-            <a href="#" target="_blank" rel="noopener noreferrer">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"></circle><polygon points="10 8 16 12 10 16 10 8"></polygon></svg>
-              <span class="i18n" data-lang="en">Demo</span><span class="i18n" data-lang="zh">演示</span>
             </a>
           </div>
         </header>
@@ -2761,7 +2760,7 @@
                    <div class="resource-top">LLaVA-OneVision-2 (GitHub)<span class="resource-badge">Code</span></div>
                   <div class="resource-meta"><span class="i18n" data-lang="en">Training code, configs, and evaluation harness.</span><span class="i18n" data-lang="zh">训练代码、配置文件与评测套件。</span></div>
                 </a>
-                <a class="resource-item" href="#">
+                <a class="resource-item" href="https://huggingface.co/collections/mvp-lab/llava-onevision-2" target="_blank" rel="noopener noreferrer">
                   <div class="resource-top">Online Demo<span class="resource-badge">Space</span></div>
                   <div class="resource-meta"><span class="i18n" data-lang="en">HuggingFace Space for interactive demo.</span><span class="i18n" data-lang="zh">HuggingFace Space 在线演示。</span></div>
                 </a>
@@ -2772,7 +2771,7 @@
                 <span class="i18n" data-lang="en">Model Checkpoints</span><span class="i18n" data-lang="zh">模型权重</span>
               </h3>
               <div class="resource-items">
-                <a class="resource-item" href="#"><div class="resource-top">LLaVA-OneVision-2-8B<span class="resource-badge">HF</span></div><div class="resource-meta">TBD</div></a>
+                <a class="resource-item" href="https://huggingface.co/collections/mvp-lab/llava-onevision-2" target="_blank" rel="noopener noreferrer"><div class="resource-top">LLaVA-OneVision-2-8B<span class="resource-badge">HF</span></div><div class="resource-meta"><span class="i18n" data-lang="en">Pretrained checkpoints on HuggingFace.</span><span class="i18n" data-lang="zh">HuggingFace 上的预训练权重。</span></div></a>
               </div>
             </div>
             <div class="resource-group wide">
@@ -2780,7 +2779,7 @@
                 <span class="i18n" data-lang="en">Training Datasets</span><span class="i18n" data-lang="zh">训练数据集</span>
               </h3>
               <div class="resource-items">
-                 <a class="resource-item" href="https://huggingface.co/datasets/mvp-lab/LLaVA-OneVision-2-Data" target="_blank" rel="noopener noreferrer"><div class="resource-top">LLaVA-OneVision-2-Data<span class="resource-badge">Dataset</span></div><div class="resource-meta"><span class="i18n" data-lang="en">Pretraining + instruction data.</span><span class="i18n" data-lang="zh">预训练 + 指令数据。</span></div></a>
+                 <a class="resource-item" href="https://huggingface.co/collections/mvp-lab/llava-onevision-2" target="_blank" rel="noopener noreferrer"><div class="resource-top">LLaVA-OneVision-2-Data<span class="resource-badge">Dataset</span></div><div class="resource-meta"><span class="i18n" data-lang="en">Pretraining + instruction data.</span><span class="i18n" data-lang="zh">预训练 + 指令数据。</span></div></a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
Bundles three homepage polish changes into a single commit. Replaces #124, #126, #127.

### 1. Hero buttons (\`docs/page/index.html\` link-row)
| Button | Before | After |
|---|---|---|
| Code | \`#\` | `https://github.com/EvolvingLMMs-Lab/LLaVA-OneVision-2` |
| Technical Report | \`#\` | `.../#citation` |
| Models & Datasets | \`#\` | `https://huggingface.co/collections/mvp-lab/llava-onevision-2` |
| Demo | \`#\` | _removed_ (no Space yet) |

### 2. Affiliations row + restyled Contributors
- Adds **GlintLab \u00b7 Lmms-Lab \u00b7 AIM-Lab \u00b7 MVP-Lab** above Contributors as a centered uppercase row with accent-dot separators
- Restyles \`.authors\` with a heading-to-accent gradient so the two lines read as a coherent hero block
- Tightens mobile breakpoint for both lines

### 3. Open-Source Resources cards
- Online Demo, LLaVA-OneVision-2-8B and LLaVA-OneVision-2-Data now all point to the unified HuggingFace collection
- Refreshes checkpoint card meta from the placeholder \`TBD\`

## Diff
\`\`\`
docs/page/assets/styles.css | 53 ++++++++++++++++++++++++++-
docs/page/index.html        | 19 +++++------
2 files changed, 60 insertions(+), 12 deletions(-)
\`\`\`

All target URLs verified HTTP 200.
