### PR TITLE
docs: update codec sampling caption

### DIFF
--- a/docs/page/index.html
+++ b/docs/page/index.html
@@ -2420,8 +2420,8 @@
           <figure class="method-figure">
             <div class="method-figure-svg" id="codec-vs-frame-chart"></div>
             <figcaption class="figure-caption">
-              <span class="i18n" data-lang="en"><strong>Figure 6.</strong> Codec-aligned sampling vs uniform frame sampling on three temporal grounding benchmarks (QVHighlights, Charades-STA, ActivityNet) across 4&ndash;64 frame budgets. Gains are largest at low frame budgets where uniform sampling under-represents motion.</span>
-              <span class="i18n" data-lang="zh"><strong>图 6.</strong> 三个时序定位基准（QVHighlights、Charades-STA、ActivityNet）上 codec 对齐采样与均匀帧采样的对比，帧预算 4&ndash;64。低帧预算下提升最显著，此时均匀采样难以覆盖运动信息。</span>
+              <span class="i18n" data-lang="en"><strong>Figure 6.</strong> Codec-aligned sampling vs uniform frame sampling across seven video and temporal grounding benchmarks, using the shared codec-vs-frame data source. Gains are largest when the frame budget is tight, including the expanded JumpScore setting up to 128 frames.</span>
+              <span class="i18n" data-lang="zh"><strong>图 6.</strong> 七个视频与时序定位基准上 codec 对齐采样与均匀帧采样的对比，数据来自同一个 codec-vs-frame 数据源。帧预算较紧时提升最明显，其中 JumpScore 扩展到 128 帧设定。</span>
             </figcaption>
           </figure>
 


### PR DESCRIPTION
## Summary
- Update the website Figure 6 caption so it matches the shared codec-vs-frame data source.
- Replace the stale three-benchmark / 4-64-frame wording with seven-benchmark coverage, including JumpScore up to 128 frames.

## Validation
- `python3` assertion for updated caption text
- `GIT_MASTER=1 git diff --check -- docs/page/index.html`