### PR TITLE
docs(readme): fix citation lead-in version and BibTeX missing comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Thanks so much to all of our amazing contributors!
 
 ## Citation
 
-If you find *LLaVA-OneVision-1.5* useful in your research, please consider to cite the following related papers:
+If you find *LLaVA-OneVision-2.0* useful in your research, please consider to cite the following related papers:
 
 ```
 @inproceedings{LLaVA-OneVision-2.0,
@@ -348,7 +348,7 @@ If you find *LLaVA-OneVision-1.5* useful in your research, please consider to ci
 @article{lillava,
   title={LLaVA-OneVision: Easy Visual Task Transfer},
   author={Li, Bo and Zhang, Yuanhan and Guo, Dong and Zhang, Renrui and Li, Feng and Zhang, Hao and Zhang, Kaichen and Zhang, Peiyuan and Li, Yanwei and Liu, Ziwei and Li, Chunyuan},
-  journal={Transactions on Machine Learning Research}
+  journal={Transactions on Machine Learning Research},
   year={2024}
 }
 ```


### PR DESCRIPTION
## Summary

Two small README typo fixes in the Citation section:

- The citation lead-in says *"If you find LLaVA-OneVision-1.5 useful..."* — but this is the 2.0 repo and the first BibTeX entry is the 2.0 citation. Updated to *LLaVA-OneVision-2.0*.
- The `lillava` BibTeX entry is missing a comma between the `journal` and `year` fields. Without it, many BibTeX parsers silently drop the `year` field.

## Test plan

- [x] Verified diff visually — only the two intended one-line changes.
- [x] Maintainer to confirm rendered README looks correct on GitHub.