### PR TITLE
chore(page): switch demo videos to webm (mp4 -> webm)

### DIFF
--- a/docs/page/index.html
+++ b/docs/page/index.html
@@ -2908,7 +2908,7 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                             <p class="demo-chat-prompt">A man takes a bag from the bottom cabinet.</p>
                             <div class="demo-chat-rgb">
                               <video muted loop playsinline preload="metadata" data-role="rgb">
-                                <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/1/full.mp4" type="video/mp4">
+                                <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/1/full.webm" type="video/webm">
                               </video>
                               <span class="demo-chat-vlabel">Charades-STA</span>
                             </div>
@@ -2926,13 +2926,13 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                             <div class="demo-chat-videos">
                               <div class="demo-chat-vid">
                                 <video muted loop playsinline preload="metadata">
-                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/1/prediction.mp4" type="video/mp4">
+                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/1/prediction.webm" type="video/webm">
                                 </video>
                                 <span class="demo-chat-vlabel">PREDICTION</span>
                               </div>
                               <div class="demo-chat-vid">
                                 <video muted loop playsinline preload="metadata">
-                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/1/ground_truth.mp4" type="video/mp4">
+                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/1/ground_truth.webm" type="video/webm">
                                 </video>
                                 <span class="demo-chat-vlabel">GROUND TRUTH</span>
                               </div>
@@ -2952,7 +2952,7 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                             <p class="demo-chat-prompt">A boy puts his hand on top of his head in the bathroom and takes a selfie with a camera.</p>
                             <div class="demo-chat-rgb">
                               <video muted loop playsinline preload="metadata" data-role="rgb">
-                                <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/2/full.mp4" type="video/mp4">
+                                <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/2/full.webm" type="video/webm">
                               </video>
                               <span class="demo-chat-vlabel">Charades-STA</span>
                             </div>
@@ -2970,13 +2970,13 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                             <div class="demo-chat-videos">
                               <div class="demo-chat-vid">
                                 <video muted loop playsinline preload="metadata">
-                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/2/prediction.mp4" type="video/mp4">
+                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/2/prediction.webm" type="video/webm">
                                 </video>
                                 <span class="demo-chat-vlabel">PREDICTION</span>
                               </div>
                               <div class="demo-chat-vid">
                                 <video muted loop playsinline preload="metadata">
-                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/2/ground_truth.mp4" type="video/mp4">
+                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/2/ground_truth.webm" type="video/webm">
                                 </video>
                                 <span class="demo-chat-vlabel">GROUND TRUTH</span>
                               </div>
@@ -2996,7 +2996,7 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                             <p class="demo-chat-prompt">A person puts on a red plaid shirt.</p>
                             <div class="demo-chat-rgb">
                               <video muted loop playsinline preload="metadata" data-role="rgb">
-                                <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/3/full.mp4" type="video/mp4">
+                                <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/3/full.webm" type="video/webm">
                               </video>
                               <span class="demo-chat-vlabel">Charades-STA</span>
                             </div>
@@ -3014,13 +3014,13 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                             <div class="demo-chat-videos">
                               <div class="demo-chat-vid">
                                 <video muted loop playsinline preload="metadata">
-                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/3/prediction.mp4" type="video/mp4">
+                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/3/prediction.webm" type="video/webm">
                                 </video>
                                 <span class="demo-chat-vlabel">PREDICTION</span>
                               </div>
                               <div class="demo-chat-vid">
                                 <video muted loop playsinline preload="metadata">
-                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/3/ground_truth.mp4" type="video/mp4">
+                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/3/ground_truth.webm" type="video/webm">
                                 </video>
                                 <span class="demo-chat-vlabel">GROUND TRUTH</span>
                               </div>
@@ -3040,7 +3040,7 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                             <p class="demo-chat-prompt">He jumps a ramp and dives into a pile of leaves.</p>
                             <div class="demo-chat-rgb">
                               <video muted loop playsinline preload="metadata" data-role="rgb">
-                                <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/4/full.mp4" type="video/mp4">
+                                <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/4/full.webm" type="video/webm">
                               </video>
                               <span class="demo-chat-vlabel">ActivityNet-Captions</span>
                             </div>
@@ -3058,13 +3058,13 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                             <div class="demo-chat-videos">
                               <div class="demo-chat-vid">
                                 <video muted loop playsinline preload="metadata">
-                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/4/prediction.mp4" type="video/mp4">
+                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/4/prediction.webm" type="video/webm">
                                 </video>
                                 <span class="demo-chat-vlabel">PREDICTION</span>
                               </div>
                               <div class="demo-chat-vid">
                                 <video muted loop playsinline preload="metadata">
-                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/4/ground_truth.mp4" type="video/mp4">
+                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/4/ground_truth.webm" type="video/webm">
                                 </video>
                                 <span class="demo-chat-vlabel">GROUND TRUTH</span>
                               </div>
@@ -3084,7 +3084,7 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                             <p class="demo-chat-prompt">A man wearing white clothes is practicing Tai Chi by the sea.</p>
                             <div class="demo-chat-rgb">
                               <video muted loop playsinline preload="metadata" data-role="rgb">
-                                <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/5/full.mp4" type="video/mp4">
+                                <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/5/full.webm" type="video/webm">
                               </video>
                               <span class="demo-chat-vlabel">ActivityNet-Captions</span>
                             </div>
@@ -3102,13 +3102,13 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                             <div class="demo-chat-videos">
                               <div class="demo-chat-vid">
                                 <video muted loop playsinline preload="metadata">
-                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/5/prediction.mp4" type="video/mp4">
+                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/5/prediction.webm" type="video/webm">
                                 </video>
                                 <span class="demo-chat-vlabel">PREDICTION</span>
                               </div>
                               <div class="demo-chat-vid">
                                 <video muted loop playsinline preload="metadata">
-                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/5/ground_truth.mp4" type="video/mp4">
+                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/5/ground_truth.webm" type="video/webm">
                                 </video>
                                 <span class="demo-chat-vlabel">GROUND TRUTH</span>
                               </div>
@@ -3128,7 +3128,7 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                             <p class="demo-chat-prompt">A boy is wearing boxing gloves practicing boxing.</p>
                             <div class="demo-chat-rgb">
                               <video muted loop playsinline preload="metadata" data-role="rgb">
-                                <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/6/full.mp4" type="video/mp4">
+                                <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/6/full.webm" type="video/webm">
                               </video>
                               <span class="demo-chat-vlabel">ActivityNet-Captions</span>
                             </div>
@@ -3146,13 +3146,13 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                             <div class="demo-chat-videos">
                               <div class="demo-chat-vid">
                                 <video muted loop playsinline preload="metadata">
-                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/6/prediction.mp4" type="video/mp4">
+                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/6/prediction.webm" type="video/webm">
                                 </video>
                                 <span class="demo-chat-vlabel">PREDICTION</span>
                               </div>
                               <div class="demo-chat-vid">
                                 <video muted loop playsinline preload="metadata">
-                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/6/ground_truth.mp4" type="video/mp4">
+                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/6/ground_truth.webm" type="video/webm">
                                 </video>
                                 <span class="demo-chat-vlabel">GROUND TRUTH</span>
                               </div>
@@ -3172,7 +3172,7 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                             <p class="demo-chat-prompt">A person washes and drains a mop in a bucket.</p>
                             <div class="demo-chat-rgb">
                               <video muted loop playsinline preload="metadata" data-role="rgb">
-                                <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/7/full.mp4" type="video/mp4">
+                                <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/7/full.webm" type="video/webm">
                               </video>
                               <span class="demo-chat-vlabel">ActivityNet-Captions</span>
                             </div>
@@ -3190,13 +3190,13 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                             <div class="demo-chat-videos">
                               <div class="demo-chat-vid">
                                 <video muted loop playsinline preload="metadata">
-                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/7/prediction.mp4" type="video/mp4">
+                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/7/prediction.webm" type="video/webm">
                                 </video>
                                 <span class="demo-chat-vlabel">PREDICTION</span>
                               </div>
                               <div class="demo-chat-vid">
                                 <video muted loop playsinline preload="metadata">
-                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/7/ground_truth.mp4" type="video/mp4">
+                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/7/ground_truth.webm" type="video/webm">
                                 </video>
                                 <span class="demo-chat-vlabel">GROUND TRUTH</span>
                               </div>
@@ -3216,7 +3216,7 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                             <p class="demo-chat-prompt">Two men are facing the camera and talking.</p>
                             <div class="demo-chat-rgb">
                               <video muted loop playsinline preload="metadata" data-role="rgb">
-                                <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/8/full.mp4" type="video/mp4">
+                                <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/8/full.webm" type="video/webm">
                               </video>
                               <span class="demo-chat-vlabel">QVHighlights</span>
                             </div>
@@ -3234,13 +3234,13 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                             <div class="demo-chat-videos">
                               <div class="demo-chat-vid">
                                 <video muted loop playsinline preload="metadata">
-                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/8/prediction.mp4" type="video/mp4">
+                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/8/prediction.webm" type="video/webm">
                                 </video>
                                 <span class="demo-chat-vlabel">PREDICTION</span>
                               </div>
                               <div class="demo-chat-vid">
                                 <video muted loop playsinline preload="metadata">
-                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/8/ground_truth.mp4" type="video/mp4">
+                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/8/ground_truth.webm" type="video/webm">
                                 </video>
                                 <span class="demo-chat-vlabel">GROUND TRUTH</span>
                               </div>
@@ -3260,7 +3260,7 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                             <p class="demo-chat-prompt">A lady taking about her beauty products.</p>
                             <div class="demo-chat-rgb">
                               <video muted loop playsinline preload="metadata" data-role="rgb">
-                                <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/9/full.mp4" type="video/mp4">
+                                <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/9/full.webm" type="video/webm">
                               </video>
                               <span class="demo-chat-vlabel">QVHighlights</span>
                             </div>
@@ -3278,13 +3278,13 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                             <div class="demo-chat-videos">
                               <div class="demo-chat-vid">
                                 <video muted loop playsinline preload="metadata">
-                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/9/prediction.mp4" type="video/mp4">
+                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/9/prediction.webm" type="video/webm">
                                 </video>
                                 <span class="demo-chat-vlabel">PREDICTION</span>
                               </div>
                               <div class="demo-chat-vid">
                                 <video muted loop playsinline preload="metadata">
-                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/9/ground_truth.mp4" type="video/mp4">
+                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/9/ground_truth.webm" type="video/webm">
                                 </video>
                                 <span class="demo-chat-vlabel">GROUND TRUTH</span>
                               </div>
@@ -3304,7 +3304,7 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                             <p class="demo-chat-prompt">The hairstylist is giving a haircut to a little boy, while the boy is playing on a tablet.</p>
                             <div class="demo-chat-rgb">
                               <video muted loop playsinline preload="metadata" data-role="rgb">
-                                <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/10/full.mp4" type="video/mp4">
+                                <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/10/full.webm" type="video/webm">
                               </video>
                               <span class="demo-chat-vlabel">QVHighlights</span>
                             </div>
@@ -3322,13 +3322,13 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                             <div class="demo-chat-videos">
                               <div class="demo-chat-vid">
                                 <video muted loop playsinline preload="metadata">
-                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/10/prediction.mp4" type="video/mp4">
+                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/10/prediction.webm" type="video/webm">
                                 </video>
                                 <span class="demo-chat-vlabel">PREDICTION</span>
                               </div>
                               <div class="demo-chat-vid">
                                 <video muted loop playsinline preload="metadata">
-                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/10/ground_truth.mp4" type="video/mp4">
+                                  <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/temporal_grounding/10/ground_truth.webm" type="video/webm">
                                 </video>
                                 <span class="demo-chat-vlabel">GROUND TRUTH</span>
                               </div>
@@ -3814,7 +3814,7 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                       </div>
                       <div class="demo-slide-video-hero">
                         <video muted loop playsinline controls preload="metadata">
-                          <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/video_manipulation/1/original.mp4" type="video/mp4">
+                          <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/video_manipulation/1/original.webm" type="video/webm">
                         </video>
                       </div>
                       <div class="demo-slide-trajectories">
@@ -3840,7 +3840,7 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
                       </div>
                       <div class="demo-slide-video-hero">
                         <video muted loop playsinline controls preload="metadata">
-                          <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/video_manipulation/2/original.mp4" type="video/mp4">
+                          <source src="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/demo/video_manipulation/2/original.webm" type="video/webm">
                         </video>
                       </div>
                       <div class="demo-slide-trajectories">


### PR DESCRIPTION
## Summary

Final follow-up to #138 / #139. Migrate Video Manipulation and Temporal Grounding video sources from `.mp4` to `.webm`, matching the existing convention used by Video Tracking demos.

## Changes

- All 32 `<source>` elements (2 manipulation + 30 temporal) updated: `.mp4` → `.webm` and `type="video/mp4"` → `type="video/webm"`.
- No HTML structural changes; pure src/type swap.

## Asset hosting

Webm assets pushed to `anxiangsir/ov2_asset` CDN in a parallel commit (`2e9a522`). Old `.mp4` files removed from the CDN so the repo stays media-only-webm.

CDN footprint dropped from 161 MB → 121 MB (~25%).

## Test plan

- [x] All 32 webm URLs verified live on CDN (HTTP 200, sample-checked across manipulation full, temporal full / prediction / ground_truth)
- [x] No remaining `.mp4` / `video/mp4` references in `docs/page/index.html`
- [x] Encoding: VP9, CRF 33, no audio, cpu-used 5 (fast preset)