### PR TITLE
chore(page): remove example-count pill from section headers

### DIFF
--- a/docs/page/index.html
+++ b/docs/page/index.html
@@ -2857,7 +2857,7 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
               <div class="demo-section-header">
                 <span class="demo-section-bar"></span>
                 <span class="demo-section-cap">Temporal Grounding</span>
-                <span class="demo-section-count">8 examples</span>
+
                 <span class="demo-section-source">TimeLens-Bench · mean IoU ≥ 0.95 over 5 runs</span>
               </div>
               <div class="demo-carousel" data-demo-carousel>
@@ -3077,7 +3077,7 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
               <div class="demo-section-header">
                 <span class="demo-section-bar"></span>
                 <span class="demo-section-cap">Video Tracking</span>
-                <span class="demo-section-count">4 examples</span>
+
                 <span class="demo-section-source">Referring video object segmentation (R-VOS)</span>
               </div>
               <div class="demo-carousel" data-demo-carousel>
@@ -3199,7 +3199,7 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
               <div class="demo-section-header">
                 <span class="demo-section-bar"></span>
                 <span class="demo-section-cap">Video Manipulation</span>
-                <span class="demo-section-count">2 examples</span>
+
                 <span class="demo-section-source">Real-world robot manipulation · online re-querying</span>
               </div>
               <div class="demo-carousel" data-demo-carousel>
@@ -3267,7 +3267,7 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
               <div class="demo-section-header">
                 <span class="demo-section-bar"></span>
                 <span class="demo-section-cap">Spatial Grounding</span>
-                <span class="demo-section-count">12 examples</span>
+
                 <span class="demo-section-source">Compositional spatial language on a single image</span>
               </div>
               <div class="demo-carousel" data-demo-carousel>


### PR DESCRIPTION
Remove the `{N} examples` pill from each Task Demos section header. The pill duplicated information already conveyed by the dots/counter below and was visually noisy. The header now reads simply: section name + source line.