### PR TITLE
docs: move VSI-Bench and ReVSI from Spatial to Video table

### DIFF
--- a/docs/page/index.html
+++ b/docs/page/index.html
@@ -1490,59 +1490,7 @@
   </td>
 </tr>
 
-            <tr class="bench-row bench-avg" data-bench="__avg_video__">
-    <td>
-      <span class="bench-avg-label">Average</span>
-    </td>
-    <td class="bench-col-hi bench-bold">62.3</td>
-    <td>58.7</td>
-    <td>56.0</td>
-    <td>50.1</td>
-    <td>44.7</td>
-    <td>41.2</td>
-  </tr>
-                </tbody>
-              </table>
-              <div class="bench-footnote">
-                <span class="i18n" data-lang="en">sub = evaluated with subtitles.</span><span class="i18n" data-lang="zh">sub = 使用字幕评测。</span>
-              </div>
-            </div>
-            </div>
-
-            <!-- Sub-table 2: Image (Spatial / Grounding / Perception) -->
-            <div class="bench-card">
-              <div class="bench-caption">
-              <span class="bench-caption-label">
-                <span class="i18n" data-lang="en">Table 1b. Spatial Benchmarks</span><span class="i18n" data-lang="zh">表 1b. 空间基准</span>
-              </span>
-              <span class="bench-tag">Results</span>
-              <span><span class="i18n" data-lang="en">Updated with current evaluation results.</span><span class="i18n" data-lang="zh">已更新为当前评测结果。</span></span>
-            </div>
-              <div class="bench-table-scroll">
-              <table class="bench-table">
-                <colgroup>
-                    <col class="bench-col-name">
-                    <col class="bench-col-spa">
-                    <col class="bench-col-other">
-                    <col class="bench-col-other">
-                    <col class="bench-col-other">
-                    <col class="bench-col-other">
-                    <col class="bench-col-other">
-                  </colgroup>
-                  <thead>
-                  <tr>
-                    <th>Benchmark</th>
-                    <th class="bench-col-hi"><span class="bench-th-name">LLaVA-OneVision-2</span><span class="bench-th-size">8B</span></th>
-                    <th><span class="bench-th-name">Qwen3-VL</span><span class="bench-th-size">8B</span></th>
-                    <th><span class="bench-th-name">Keye-VL-1.5</span><span class="bench-th-size">8B</span></th>
-                    <th><span class="bench-th-name">InternVL-3.5</span><span class="bench-th-size">8B</span></th>
-                    <th><span class="bench-th-name">PLM</span><span class="bench-th-size">8B</span></th>
-                    <th><span class="bench-th-name">LLaVA-OV-1.5</span><span class="bench-th-size">8B</span></th>
-                  </tr>
-                </thead>
-                <tbody>
-
-  <tr class="bench-row bench-section-top" data-bench="vsi-bench">
+  <tr class="bench-row" data-bench="vsi-bench">
     <td>
       <button class="bench-expand" aria-expanded="false" aria-label="Expand">
         <svg viewBox="0 0 12 12" aria-hidden="true"><path d="M3 4.5l3 3 3-3"/></svg>
@@ -1598,7 +1546,59 @@
     </div>
   </td>
 </tr>
-  <tr class="bench-row" data-bench="crpe">
+            <tr class="bench-row bench-avg" data-bench="__avg_video__">
+    <td>
+      <span class="bench-avg-label">Average</span>
+    </td>
+    <td class="bench-col-hi bench-bold">62.5</td>
+    <td>58.2</td>
+    <td>53.6</td>
+    <td>50.3</td>
+    <td>43.0</td>
+    <td>40.1</td>
+  </tr>
+                </tbody>
+              </table>
+              <div class="bench-footnote">
+                <span class="i18n" data-lang="en">sub = evaluated with subtitles.</span><span class="i18n" data-lang="zh">sub = 使用字幕评测。</span>
+              </div>
+            </div>
+            </div>
+
+            <!-- Sub-table 2: Image (Spatial / Grounding / Perception) -->
+            <div class="bench-card">
+              <div class="bench-caption">
+              <span class="bench-caption-label">
+                <span class="i18n" data-lang="en">Table 1b. Spatial Benchmarks</span><span class="i18n" data-lang="zh">表 1b. 空间基准</span>
+              </span>
+              <span class="bench-tag">Results</span>
+              <span><span class="i18n" data-lang="en">Updated with current evaluation results.</span><span class="i18n" data-lang="zh">已更新为当前评测结果。</span></span>
+            </div>
+              <div class="bench-table-scroll">
+              <table class="bench-table">
+                <colgroup>
+                    <col class="bench-col-name">
+                    <col class="bench-col-spa">
+                    <col class="bench-col-other">
+                    <col class="bench-col-other">
+                    <col class="bench-col-other">
+                    <col class="bench-col-other">
+                    <col class="bench-col-other">
+                  </colgroup>
+                  <thead>
+                  <tr>
+                    <th>Benchmark</th>
+                    <th class="bench-col-hi"><span class="bench-th-name">LLaVA-OneVision-2</span><span class="bench-th-size">8B</span></th>
+                    <th><span class="bench-th-name">Qwen3-VL</span><span class="bench-th-size">8B</span></th>
+                    <th><span class="bench-th-name">Keye-VL-1.5</span><span class="bench-th-size">8B</span></th>
+                    <th><span class="bench-th-name">InternVL-3.5</span><span class="bench-th-size">8B</span></th>
+                    <th><span class="bench-th-name">PLM</span><span class="bench-th-size">8B</span></th>
+                    <th><span class="bench-th-name">LLaVA-OV-1.5</span><span class="bench-th-size">8B</span></th>
+                  </tr>
+                </thead>
+                <tbody>
+
+  <tr class="bench-row bench-section-top" data-bench="crpe">
     <td>
       <button class="bench-expand" aria-expanded="false" aria-label="Expand">
         <svg viewBox="0 0 12 12" aria-hidden="true"><path d="M3 4.5l3 3 3-3"/></svg>
@@ -1908,12 +1908,12 @@
     <td>
       <span class="bench-avg-label">Average</span>
     </td>
-    <td class="bench-col-hi bench-bold">63.6</td>
-    <td>57.5</td>
-    <td>48.7</td>
-    <td>52.8</td>
-    <td>46.4</td>
-    <td>48.1</td>
+    <td class="bench-col-hi bench-bold">63.5</td>
+    <td>58.2</td>
+    <td>51.3</td>
+    <td>53.0</td>
+    <td>49.5</td>
+    <td>51.1</td>
   </tr>
                 </tbody>
               </table>


### PR DESCRIPTION
## Summary
- Move **VSI-Bench** and **ReVSI** rows (with their `bench-detail` content) out of the Spatial Benchmarks table (Table 1b) and into the Video Benchmarks table (Table 1a), since both benchmarks evaluate visual-spatial reasoning from egocentric video.
- Recompute the Average row of both tables over their new row sets:
  - **Video** (18 rows): 62.5 / 58.2 / 53.6 / 50.3 / 43.0 / 40.1
  - **Spatial** (11 rows): 63.5 / 58.2 / 51.3 / 53.0 / 49.5 / 51.1
- Move the `bench-section-top` class from VSI-Bench to CRPE so that the Spatial table still has its visual section header on the new first row.

## Test plan
- [ ] Open `docs/page/index.html` and confirm VSI-Bench / ReVSI appear at the bottom of Table 1a (Video) and no longer appear in Table 1b (Spatial).
- [ ] Confirm both Average rows render with the updated numbers.
- [ ] Confirm the top border of the Spatial table still looks correct (CRPE is now the section-top row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)