### PR TITLE
docs(page): fix Models link slug and regenerate codec-vs-frame SVGs

### DIFF
--- a/asset/method_codec_vs_frame_dark.svg
+++ b/asset/method_codec_vs_frame_dark.svg
@@ -141,7 +141,7 @@ g[id^="cvf-panel-"]{animation:cvf-fade .4s ease-out both}
 </g>
 <g id="cvf-panel-4" transform="translate(-12.00,256.00)" style="animation-delay:0.32s">
 <text x="48" y="99" class="panel-title">VideoMME-Long-Sub</text>
-<text x="48" y="111" class="subhead">peak +7.2  ·  8f Δ +6.2  ·  128f Δ +4.4</text>
+<text x="48" y="111" class="subhead">peak +2.6  ·  8f Δ +1.5  ·  128f Δ -0.1</text>
 <line x1="48" y1="294.0" x2="238" y2="294.0" class="grid" />
 <text x="42" y="297.0" text-anchor="end" class="tick">50</text>
 <line x1="48" y1="204.0" x2="238" y2="204.0" class="grid" />
@@ -156,17 +156,17 @@ g[id^="cvf-panel-"]{animation:cvf-fade .4s ease-out both}
 <line class="grid" x1="190.5" y1="114" x2="190.5" y2="294" />
 <text x="238.0" y="316.0" text-anchor="middle" class="tick">128</text>
 <line class="grid" x1="238.0" y1="114" x2="238.0" y2="294" />
-<polygon points="48.0,287.7 95.5,249.0 143.0,228.3 190.5,211.2 238.0,175.2 238.0,135.6 190.5,146.4 143.0,176.1 95.5,211.2 48.0,231.9" opacity="0.4" class="advantage" />
+<polygon points="48.0,248.1 95.5,224.7 143.0,186.0 190.5,160.8 238.0,140.1 238.0,141.0 190.5,137.4 143.0,191.4 95.5,201.3 48.0,234.6" opacity="0.4" class="advantage" />
 <line x1="48" y1="114" x2="48" y2="294" class="axis" />
 <line x1="48" y1="294" x2="238" y2="294" class="axis" />
-<polyline points="48.0,287.7 95.5,249.0 143.0,228.3 190.5,211.2 238.0,175.2" fill="none" stroke-width="1.3" stroke-dasharray="3 2" class="frame-line" />
-<polyline class="codec-line" points="48.0,231.9 95.5,211.2 143.0,176.1 190.5,146.4 238.0,135.6" fill="none" stroke-width="1.8" />
-<text x="244" y="139.6" class="score-codec">67.6</text>
-<text x="244" y="179.2" class="score-frame">63.2</text>
+<polyline points="48.0,248.1 95.5,224.7 143.0,186.0 190.5,160.8 238.0,140.1" fill="none" stroke-width="1.3" stroke-dasharray="3 2" class="frame-line" />
+<polyline class="codec-line" points="48.0,234.6 95.5,201.3 143.0,191.4 190.5,137.4 238.0,141.0" fill="none" stroke-width="1.8" />
+<text x="244" y="145.0" class="score-codec">67.0</text>
+<text x="244" y="144.1" class="score-frame">67.1</text>
 </g>
 <g id="cvf-panel-5" transform="translate(258.00,256.00)" style="animation-delay:0.40s">
 <text x="48" y="99" class="panel-title">VideoEval-Pro</text>
-<text x="48" y="111" class="subhead">peak +3.4  ·  8f Δ +3.1  ·  128f Δ +1.5</text>
+<text x="48" y="111" class="subhead">peak +3.5  ·  8f Δ +3.3  ·  128f Δ +1.8</text>
 <line x1="48" y1="294.0" x2="238" y2="294.0" class="grid" />
 <text x="42" y="297.0" text-anchor="end" class="tick">42</text>
 <line x1="48" y1="249.0" x2="238" y2="249.0" class="grid" />
@@ -185,12 +185,12 @@ g[id^="cvf-panel-"]{animation:cvf-fade .4s ease-out both}
 <line class="grid" x1="190.5" y1="114" x2="190.5" y2="294" />
 <text x="238.0" y="316.0" text-anchor="middle" class="tick">128</text>
 <line class="grid" x1="238.0" y1="114" x2="238.0" y2="294" />
-<polygon points="48.0,281.6 95.5,262.5 143.0,219.8 190.5,178.1 238.0,159.0 238.0,142.1 190.5,162.4 143.0,188.2 95.5,224.2 48.0,246.7" opacity="0.4" class="advantage" />
+<polygon points="48.0,281.6 95.5,262.5 143.0,219.8 190.5,178.1 238.0,159.0 238.0,138.8 190.5,160.1 143.0,186.0 95.5,223.1 48.0,244.5" opacity="0.4" class="advantage" />
 <line x1="48" y1="114" x2="48" y2="294" class="axis" />
 <line x1="48" y1="294" x2="238" y2="294" class="axis" />
 <polyline points="48.0,281.6 95.5,262.5 143.0,219.8 190.5,178.1 238.0,159.0" fill="none" stroke-width="1.3" stroke-dasharray="3 2" class="frame-line" />
-<polyline class="codec-line" points="48.0,246.7 95.5,224.2 143.0,188.2 190.5,162.4 238.0,142.1" fill="none" stroke-width="1.8" />
-<text x="244" y="146.1" class="score-codec">55.5</text>
+<polyline class="codec-line" points="48.0,244.5 95.5,223.1 143.0,186.0 190.5,160.1 238.0,138.8" fill="none" stroke-width="1.8" />
+<text x="244" y="142.8" class="score-codec">55.8</text>
 <text x="244" y="163.0" class="score-frame">54.0</text>
 </g>
 <g id="cvf-panel-6" transform="translate(528.00,256.00)" style="animation-delay:0.48s">
@@ -225,11 +225,11 @@ g[id^="cvf-panel-"]{animation:cvf-fade .4s ease-out both}
 <g id="cvf-panel-7" transform="translate(798.00,256.00)" style="animation-delay:0.56s">
 <text x="48" y="99" class="panel-title">Overall Averages</text>
 <text x="48" y="140" class="subhead summary-text">Average Peak Δ</text>
-<text x="210" y="140" class="score-codec summary-text">+15.6</text>
+<text x="210" y="140" class="score-codec summary-text">+14.9</text>
 <text x="48" y="170" class="subhead summary-text">Codec @ Max (Avg)</text>
 <text x="210" y="170" class="score-codec summary-text">58.9</text>
 <text x="48" y="200" class="subhead summary-text">Frame @ Max (Avg)</text>
-<text x="210" y="200" class="score-frame">53.5</text>
+<text x="210" y="200" class="score-frame">54.0</text>
 <text x="48" y="250" class="subhead muted-text">Codec sampling consistently</text>
 <text x="48" y="270" class="subhead muted-text">extends temporal coverage and</text>
 <text x="48" y="290" class="subhead muted-text">peak performance overall.</text>

--- a/asset/method_codec_vs_frame_light.svg
+++ b/asset/method_codec_vs_frame_light.svg
@@ -141,7 +141,7 @@ g[id^="cvf-panel-"]{animation:cvf-fade .4s ease-out both}
 </g>
 <g id="cvf-panel-4" transform="translate(-12.00,256.00)" style="animation-delay:0.32s">
 <text x="48" y="99" class="panel-title">VideoMME-Long-Sub</text>
-<text x="48" y="111" class="subhead">peak +7.2  ·  8f Δ +6.2  ·  128f Δ +4.4</text>
+<text x="48" y="111" class="subhead">peak +2.6  ·  8f Δ +1.5  ·  128f Δ -0.1</text>
 <line x1="48" y1="294.0" x2="238" y2="294.0" class="grid" />
 <text x="42" y="297.0" text-anchor="end" class="tick">50</text>
 <line x1="48" y1="204.0" x2="238" y2="204.0" class="grid" />
@@ -156,17 +156,17 @@ g[id^="cvf-panel-"]{animation:cvf-fade .4s ease-out both}
 <line class="grid" x1="190.5" y1="114" x2="190.5" y2="294" />
 <text x="238.0" y="316.0" text-anchor="middle" class="tick">128</text>
 <line class="grid" x1="238.0" y1="114" x2="238.0" y2="294" />
-<polygon points="48.0,287.7 95.5,249.0 143.0,228.3 190.5,211.2 238.0,175.2 238.0,135.6 190.5,146.4 143.0,176.1 95.5,211.2 48.0,231.9" opacity="0.4" class="advantage" />
+<polygon points="48.0,248.1 95.5,224.7 143.0,186.0 190.5,160.8 238.0,140.1 238.0,141.0 190.5,137.4 143.0,191.4 95.5,201.3 48.0,234.6" opacity="0.4" class="advantage" />
 <line x1="48" y1="114" x2="48" y2="294" class="axis" />
 <line x1="48" y1="294" x2="238" y2="294" class="axis" />
-<polyline points="48.0,287.7 95.5,249.0 143.0,228.3 190.5,211.2 238.0,175.2" fill="none" stroke-width="1.3" stroke-dasharray="3 2" class="frame-line" />
-<polyline class="codec-line" points="48.0,231.9 95.5,211.2 143.0,176.1 190.5,146.4 238.0,135.6" fill="none" stroke-width="1.8" />
-<text x="244" y="139.6" class="score-codec">67.6</text>
-<text x="244" y="179.2" class="score-frame">63.2</text>
+<polyline points="48.0,248.1 95.5,224.7 143.0,186.0 190.5,160.8 238.0,140.1" fill="none" stroke-width="1.3" stroke-dasharray="3 2" class="frame-line" />
+<polyline class="codec-line" points="48.0,234.6 95.5,201.3 143.0,191.4 190.5,137.4 238.0,141.0" fill="none" stroke-width="1.8" />
+<text x="244" y="145.0" class="score-codec">67.0</text>
+<text x="244" y="144.1" class="score-frame">67.1</text>
 </g>
 <g id="cvf-panel-5" transform="translate(258.00,256.00)" style="animation-delay:0.40s">
 <text x="48" y="99" class="panel-title">VideoEval-Pro</text>
-<text x="48" y="111" class="subhead">peak +3.4  ·  8f Δ +3.1  ·  128f Δ +1.5</text>
+<text x="48" y="111" class="subhead">peak +3.5  ·  8f Δ +3.3  ·  128f Δ +1.8</text>
 <line x1="48" y1="294.0" x2="238" y2="294.0" class="grid" />
 <text x="42" y="297.0" text-anchor="end" class="tick">42</text>
 <line x1="48" y1="249.0" x2="238" y2="249.0" class="grid" />
@@ -185,12 +185,12 @@ g[id^="cvf-panel-"]{animation:cvf-fade .4s ease-out both}
 <line class="grid" x1="190.5" y1="114" x2="190.5" y2="294" />
 <text x="238.0" y="316.0" text-anchor="middle" class="tick">128</text>
 <line class="grid" x1="238.0" y1="114" x2="238.0" y2="294" />
-<polygon points="48.0,281.6 95.5,262.5 143.0,219.8 190.5,178.1 238.0,159.0 238.0,142.1 190.5,162.4 143.0,188.2 95.5,224.2 48.0,246.7" opacity="0.4" class="advantage" />
+<polygon points="48.0,281.6 95.5,262.5 143.0,219.8 190.5,178.1 238.0,159.0 238.0,138.8 190.5,160.1 143.0,186.0 95.5,223.1 48.0,244.5" opacity="0.4" class="advantage" />
 <line x1="48" y1="114" x2="48" y2="294" class="axis" />
 <line x1="48" y1="294" x2="238" y2="294" class="axis" />
 <polyline points="48.0,281.6 95.5,262.5 143.0,219.8 190.5,178.1 238.0,159.0" fill="none" stroke-width="1.3" stroke-dasharray="3 2" class="frame-line" />
-<polyline class="codec-line" points="48.0,246.7 95.5,224.2 143.0,188.2 190.5,162.4 238.0,142.1" fill="none" stroke-width="1.8" />
-<text x="244" y="146.1" class="score-codec">55.5</text>
+<polyline class="codec-line" points="48.0,244.5 95.5,223.1 143.0,186.0 190.5,160.1 238.0,138.8" fill="none" stroke-width="1.8" />
+<text x="244" y="142.8" class="score-codec">55.8</text>
 <text x="244" y="163.0" class="score-frame">54.0</text>
 </g>
 <g id="cvf-panel-6" transform="translate(528.00,256.00)" style="animation-delay:0.48s">
@@ -225,11 +225,11 @@ g[id^="cvf-panel-"]{animation:cvf-fade .4s ease-out both}
 <g id="cvf-panel-7" transform="translate(798.00,256.00)" style="animation-delay:0.56s">
 <text x="48" y="99" class="panel-title">Overall Averages</text>
 <text x="48" y="140" class="subhead summary-text">Average Peak Δ</text>
-<text x="210" y="140" class="score-codec summary-text">+15.6</text>
+<text x="210" y="140" class="score-codec summary-text">+14.9</text>
 <text x="48" y="170" class="subhead summary-text">Codec @ Max (Avg)</text>
 <text x="210" y="170" class="score-codec summary-text">58.9</text>
 <text x="48" y="200" class="subhead summary-text">Frame @ Max (Avg)</text>
-<text x="210" y="200" class="score-frame">53.5</text>
+<text x="210" y="200" class="score-frame">54.0</text>
 <text x="48" y="250" class="subhead muted-text">Codec sampling consistently</text>
 <text x="48" y="270" class="subhead muted-text">extends temporal coverage and</text>
 <text x="48" y="290" class="subhead muted-text">peak performance overall.</text>

--- a/docs/page/index.html
+++ b/docs/page/index.html
@@ -147,7 +147,7 @@
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
               <span class="i18n" data-lang="en">Technical Report</span><span class="i18n" data-lang="zh">技术报告</span>
             </a>
-            <a href="https://huggingface.co/lmms-lab-encoder/LLaVA-OneVision2-8B-Instruct" target="_blank" rel="noopener noreferrer">
+            <a href="https://huggingface.co/lmms-lab-encoder/LLaVA-OneVision-2-8B-Instruct" target="_blank" rel="noopener noreferrer">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="16.5" y1="9.4" x2="7.5" y2="4.21"></line><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
               <span class="i18n" data-lang="en">Models</span><span class="i18n" data-lang="zh">模型</span>
             </a>


### PR DESCRIPTION
## Summary

Two small fix-ups that landed on `docs/page-updates-may` after #155 was already merged:

### 1. Fix Models button URL slug
The HuggingFace repo is at `lmms-lab-encoder/LLaVA-OneVision-2-8B-Instruct` (hyphen between "OneVision" and "2"). #155 introduced the Models / Datasets button split with a hyphenless slug that 404'd; this PR corrects it.

### 2. Regenerate Codec vs Frame chart SVGs
Re-run `docs/llava_onevision2/render_codec_vs_frame.py` against the updated `codec-vs-frame-data.json` so the README's Codec vs Frame chart matches the page-side chart.

Effective data deltas in the chart (last-point labels):
- **videomme-long-sub**: `63.2 / 67.6` → `67.1 / 67.0`
- **videoeval-pro** codec: `55.5` → `55.8`

The performance-table SVGs are intentionally left untouched — `results.csv` did not change in this branch, and re-rendering would only churn matplotlib-generated internal element IDs.

## Test plan
- [ ] Open `docs/page/index.html`, click the **Models** button — should reach the live HuggingFace page for `LLaVA-OneVision-2-8B-Instruct` (not 404).
- [ ] Open the README on GitHub and confirm the Codec vs Frame chart shows the new endpoint labels for videomme-long-sub and videoeval-pro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
