### PR TITLE
docs(page): reorder and rename affiliations

### DIFF
--- a/docs/page/index.html
+++ b/docs/page/index.html
@@ -129,7 +129,7 @@
             </span>
           </div>
           <div class="affiliations">
-            <span>GlintLab</span><span>Lmms-Lab</span><span>AIM-Lab</span><span>MVP-Lab</span>
+            <span>Lmms-Lab</span><span>Glint-Lab</span><span>AIM for Health Lab</span><span>MVP-Lab</span>
           </div>
           <div class="authors"><span class="i18n" data-lang="en">LLaVA-OneVision-2 Contributors</span><span class="i18n" data-lang="zh">LLaVA-OneVision-2 贡献者</span></div>
           <p class="lede i18n" data-lang="en">


### PR DESCRIPTION
## Summary

Reorder and rename the affiliations row under the page title.

- Move **Lmms-Lab** to the front.
- **GlintLab** → **Glint-Lab**
- **AIM-Lab** → **AIM for Health Lab**

Final order: `Lmms-Lab · Glint-Lab · AIM for Health Lab · MVP-Lab`.

## Test plan
- [ ] Open `docs/page/index.html`, confirm the affiliations row directly under the title reads in the new order with the new spellings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
