### PR TITLE
docs(page): renumber figures by visual reading order

### DIFF
--- a/docs/page/index.html
+++ b/docs/page/index.html
@@ -294,8 +294,8 @@
           <figure class="method-figure">
             <img src="./assets/roadmap.png" alt="LLaVA-OneVision-2 roadmap" style="width:100%;height:auto;display:block;">
             <figcaption class="figure-caption">
-              <span class="i18n" data-lang="en"><strong>Figure 1.</strong> Roadmap of video understanding from token compression to codec-aligned perceptual intelligence. The roadmap traces the evolution from early frame/clip sampling and hand-crafted visual features, to heuristic token compression, learned token selection, and the 2026 codec-aligned paradigm represented by LLaVA-OneVision-2.</span>
-              <span class="i18n" data-lang="zh"><strong>图 1.</strong> 视频理解的路线图：从 token 压缩到 codec 对齐的感知智能。路线图勾勒出从早期的帧/片段采样与手工视觉特征，到启发式 token 压缩、可学习的 token 选择，再到由 LLaVA-OneVision-2 代表的 2026 codec 对齐范式的演进过程。</span>
+              <span class="i18n" data-lang="en"><strong>Figure 2.</strong> Roadmap of video understanding from token compression to codec-aligned perceptual intelligence. The roadmap traces the evolution from early frame/clip sampling and hand-crafted visual features, to heuristic token compression, learned token selection, and the 2026 codec-aligned paradigm represented by LLaVA-OneVision-2.</span>
+              <span class="i18n" data-lang="zh"><strong>图 2.</strong> 视频理解的路线图：从 token 压缩到 codec 对齐的感知智能。路线图勾勒出从早期的帧/片段采样与手工视觉特征，到启发式 token 压缩、可学习的 token 选择，再到由 LLaVA-OneVision-2 代表的 2026 codec 对齐范式的演进过程。</span>
             </figcaption>
           </figure>
         </section>
@@ -335,7 +335,7 @@
   <rect width="1080" height="480" fill="#ffffff"/>
 
   <!-- ===== Header ===== -->
-  <text x="60" y="44" class="fig-label">Figure 2</text>
+  <text x="60" y="44" class="fig-label">Figure 3</text>
   <text x="60" y="72" class="fig-title">Codec-aligned patch selection</text>
   <text x="60" y="94" class="fig-sub">Same 54-token budget. Codec-aligned selection covers 3&#215; the temporal range by keeping I-frames dense and P-frames sparse.</text>
   <line x1="60" y1="114" x2="1020" y2="114" class="divider"/>
@@ -544,8 +544,8 @@
   </g>
 </svg></div>
             <figcaption class="figure-caption">
-              <span class="i18n" data-lang="en"><strong>Figure 2.</strong> Codec-style patch selection. Same 54-token budget as uniform sampling, but spans 3× the temporal range by keeping I-frames dense and skimming only motion-rich patches from P-frames.</span>
-              <span class="i18n" data-lang="zh"><strong>图 2.</strong> Codec 风格的 patch 选择。与均匀采样使用同样的 54 token 预算，但通过保留 I 帧密集采样、仅从 P 帧抽取运动相关 patch，可覆盖 3 倍的时间范围。</span>
+              <span class="i18n" data-lang="en"><strong>Figure 3.</strong> Codec-style patch selection. Same 54-token budget as uniform sampling, but spans 3× the temporal range by keeping I-frames dense and skimming only motion-rich patches from P-frames.</span>
+              <span class="i18n" data-lang="zh"><strong>图 3.</strong> Codec 风格的 patch 选择。与均匀采样使用同样的 54 token 预算，但通过保留 I 帧密集采样、仅从 P 帧抽取运动相关 patch，可覆盖 3 倍的时间范围。</span>
             </figcaption>
           </figure>
 
@@ -613,7 +613,7 @@
     </style>
   </defs>
   <rect width="1080" height="466" fill="#ffffff"/>
-  <text x="60" y="22" class="subtitle">Figure 3 · One Encoder, Every Modality</text>
+  <text x="60" y="22" class="subtitle">Figure 4 · One Encoder, Every Modality</text>
   <text x="60" y="42" class="title">OneVision-Encoder · three input types, same token grid.</text>
   <text x="60" y="58" class="panel-sub">All three input types flow through the <tspan font-weight="700" fill="#2563eb">same OneVision-Encoder</tspan> under shared <tspan font-weight="700" fill="#0f172a" font-family="'SF Mono', 'Menlo', monospace">(t,&#8239;h,&#8239;w)</tspan> positions.</text>
   <line x1="60" y1="68" x2="1020" y2="68" class="divider"/>
@@ -996,8 +996,8 @@
   </g>
 </svg></div>
             <figcaption class="figure-caption">
-              <span class="i18n" data-lang="en"><strong>Figure 3.</strong> One encoder, three input modalities. Image, uniform-frame video, and codec-aligned video all flow through the same OneVision-Encoder under shared <code>(t, h, w)</code> positions.</span>
-              <span class="i18n" data-lang="zh"><strong>图 3.</strong> 单一编码器统一处理三种模态输入。图像、均匀帧视频与 codec 对齐视频均通过同一 OneVision-Encoder，并共享 <code>(t, h, w)</code> 位置编码。</span>
+              <span class="i18n" data-lang="en"><strong>Figure 4.</strong> One encoder, three input modalities. Image, uniform-frame video, and codec-aligned video all flow through the same OneVision-Encoder under shared <code>(t, h, w)</code> positions.</span>
+              <span class="i18n" data-lang="zh"><strong>图 4.</strong> 单一编码器统一处理三种模态输入。图像、均匀帧视频与 codec 对齐视频均通过同一 OneVision-Encoder，并共享 <code>(t, h, w)</code> 位置编码。</span>
             </figcaption>
           </figure>
         </section>
@@ -2441,8 +2441,8 @@
           <figure class="method-figure">
             <div class="method-figure-svg" id="codec-vs-frame-chart"></div>
             <figcaption class="figure-caption">
-              <span class="i18n" data-lang="en"><strong>Figure 4.</strong> Codec-stream input vs uniform frame sampling across seven video and temporal grounding benchmarks, using the shared codec-vs-frame data source. Gains are largest when the frame budget is tight, including the expanded JumpScore setting up to 128 frames.</span>
-              <span class="i18n" data-lang="zh"><strong>图 4.</strong> 七个视频与时序定位基准上 codec 流式输入与均匀帧采样的对比，数据来自同一个 codec-vs-frame 数据源。帧预算较紧时提升最明显，其中 JumpScore 扩展到 128 帧设定。</span>
+              <span class="i18n" data-lang="en"><strong>Figure 5.</strong> Codec-stream input vs uniform frame sampling across seven video and temporal grounding benchmarks, using the shared codec-vs-frame data source. Gains are largest when the frame budget is tight, including the expanded JumpScore setting up to 128 frames.</span>
+              <span class="i18n" data-lang="zh"><strong>图 5.</strong> 七个视频与时序定位基准上 codec 流式输入与均匀帧采样的对比，数据来自同一个 codec-vs-frame 数据源。帧预算较紧时提升最明显，其中 JumpScore 扩展到 128 帧设定。</span>
             </figcaption>
           </figure>
 
@@ -2570,8 +2570,8 @@
               </div>
             </div>
             <figcaption class="figure-caption">
-              <span class="i18n" data-lang="en"><strong>Figure 5.</strong> A jump-rope sample rendered on the codec timeline. The uniform-frame view is held to its nearest frame among 128 evenly spaced samples, while the codec view follows dense selected evidence and highlights the retained patches in orange.</span>
-              <span class="i18n" data-lang="zh"><strong>图 5.</strong> 一个跳绳样本，按 codec 时间轴渲染。左侧均匀帧视图只显示 128 个均匀采样帧中的最近帧；右侧 codec 视图跟随更密集的选中证据，并用绿色框标出保留的 patch。</span>
+              <span class="i18n" data-lang="en"><strong>Figure 1.</strong> A jump-rope sample rendered on the codec timeline. The uniform-frame view is held to its nearest frame among 128 evenly spaced samples, while the codec view follows dense selected evidence and highlights the retained patches in orange.</span>
+              <span class="i18n" data-lang="zh"><strong>图 1.</strong> 一个跳绳样本，按 codec 时间轴渲染。左侧均匀帧视图只显示 128 个均匀采样帧中的最近帧；右侧 codec 视图跟随更密集的选中证据，并用绿色框标出保留的 patch。</span>
             </figcaption>
           </figure>
         </section>


### PR DESCRIPTION
## Summary

Renumber figures by **visual reading order**.

The `codec-demo-figure` (jump-rope sample) is cloned into the top-of-page spotlight via JS (`#codec-demo-spotlight-slot`), so it is the first figure the reader sees — but it was labeled "Figure 5", with Figure 1 (Roadmap) appearing later. That's confusing. This PR fixes the order:

| Visual order | New | Content | Previous |
|---|---|---|---|
| 1 (top spotlight + codec-vs-frame section) | **Figure 1** | Jump-rope sample on codec timeline | Figure 5 |
| 2 | **Figure 2** | Roadmap | Figure 1 |
| 3 | **Figure 3** | Codec-style patch selection | Figure 2 |
| 4 | **Figure 4** | One encoder, three modalities | Figure 3 |
| 5 | **Figure 5** | Codec-stream input vs uniform (chart) | Figure 4 |
| 6 | **Figure 6** | OneVision-Encoder architecture | Figure 6 (unchanged) |

Both English and Chinese captions are updated, and the inner SVG title labels for figures 3 and 4 (the two `method-figure` SVGs) are kept in sync with the figcaption numbers.

## Test plan
- [ ] Open `docs/page/index.html`, force-refresh. The top spotlight figure now reads "Figure 1. A jump-rope sample…".
- [ ] Scroll down: figures appear as 1 → 2 → 3 → 4 → 5 → 6 with no gaps or duplicates (the jump-rope figure appears once at the top and once in the codec-vs-frame section; both copies show "Figure 1").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
