### PR TITLE
docs: fix minor typos

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ author_email = ''
 version = 0.1.0
 # A brief introduction about the project, ANY NON-ENGLISH CHARACTER IS NOT SUPPORTED!
 description = project descriptions here
-# A longer version of introduction abouth the project, you can also include readme, change log, etc. .md or rst file is recommended.
+# A longer version of introduction about the project, you can also include readme, change log, etc. .md or rst file is recommended.
 long_description = file: README.md, CHANGELOG.md
 long_description_content_type = text/markdown
 # Main page of the project, usually the project's icode page, you can set to its wiki or other documents url instead.
@@ -42,7 +42,7 @@ packages = find:
 #     six >= 1.10
 
 # Test dependencies, all dependencies for tests here. The format is align to install_requires.
-# You can use the internal unittest, or the simplier framework such as pytest or nose.
+# You can use the internal unittest, or the simpler framework such as pytest or nose.
 # python3 has a mock library with itself, but it's not exist in python 2, add as you need.
 #tests_require =
 #    pytest
@@ -50,7 +50,7 @@ packages = find:
 
 # directory for unit test
 test_suite = aiak_training_llm.tests
-# add all data files controled by git
+# add all data files controlled by git
 include_package_data = True
 # You can run zip source code for plain python project
 zip_safe = False


### PR DESCRIPTION
## Summary

This PR fixes a few minor typos and grammar issues in `setup.cfg` comments:

- `abouth` -> `about`
- `simplier` -> `simpler`
- `controled` -> `controlled`

No code behavior is changed.