### PR TITLE
docs(readme): add repo clone step to agent fast path for Quick Start (4B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,17 +176,31 @@ The curriculum mixes LLaVA-OneVision-1.5 data, FineVision, and new in-house vide
 <details>
 <summary><strong>🤖 Agent fast path — one block, idempotent (click to expand)</strong></summary>
 
-> **For code agents (Claude Code / opencode / etc.):** copy-paste this entire block from `<REPO_ROOT>` and run it. It re-runs safely — every step is guarded by an existence check, so it skips the 340 GB download if the bundle is already there and skips `docker load` if the image is already loaded. Human readers should follow the numbered sections (§0–§5) below instead.
+> **For code agents (Claude Code / opencode / etc.):** copy-paste this entire block from any working directory and run it. It self-bootstraps — clones the repo if missing, downloads the 340 GB bundle if missing, loads the docker image if missing, then launches training. Every step is guarded by an existence check, so re-runs are safe. Human readers should follow the numbered sections (§0–§5) below instead.
 
 ```bash
-# Run from <REPO_ROOT>. Requires: 8 GPUs, Docker + NVIDIA Container Toolkit,
-# huggingface-cli (only used if the bundle is missing).
+# Run from any working directory. Requires: 8 GPUs, Docker + NVIDIA Container Toolkit,
+# git, huggingface-cli (only used if the bundle is missing).
 set -euo pipefail
 
+REPO_URL="https://github.com/EvolvingLMMs-Lab/LLaVA-OneVision-2.git"
+REPO_DIR="LLaVA-OneVision-2"
 BUNDLE_DIR="./ov2_quickstart"
 IMAGE="llava_megatron:26.05"
-OUTPUT_DIR="$(pwd)/output/quick_start_4b"
 CONTAINER_NAME="ov2_quickstart_4b"
+
+# 0) Repo — clone if the target script isn't reachable from $(pwd).
+#    If you're already inside the repo, this is a no-op and we stay put.
+if [ -f "./examples/llava_onevision2/quick_start_4b/quick_start.sh" ]; then
+    echo "[skip] already inside repo root at $(pwd)"
+elif [ -f "./${REPO_DIR}/examples/llava_onevision2/quick_start_4b/quick_start.sh" ]; then
+    echo "[skip] repo already cloned at ./${REPO_DIR}"
+    cd "${REPO_DIR}"
+else
+    git clone --depth 1 "${REPO_URL}" "${REPO_DIR}"
+    cd "${REPO_DIR}"
+fi
+OUTPUT_DIR="$(pwd)/output/quick_start_4b"
 
 # 1) Bundle (~340 GB) — skip if the three required subdirs already exist.
 if [ -d "${BUNDLE_DIR}/packed_mixed_sft_cap_v30s/node_a/webdataset" ] \


### PR DESCRIPTION
## Summary

- The agent fast-path block in the Quick Start (4B) section assumed the agent was already in `<REPO_ROOT>`, but never told it how to get there.
- A fresh code agent on a fresh machine has no instruction to clone the repo, so the block would fail at the `docker run` step because `$(pwd)` wouldn't contain `examples/llava_onevision2/quick_start_4b/quick_start.sh`.
- This PR adds an idempotent **Step 0 (Repo)** that self-bootstraps the clone, keeping the rest of the block (bundle, image, container) unchanged.

## What changed

A new Step 0 inside the fast-path bash block with three branches:

1. **Already inside the repo root** (`./examples/llava_onevision2/quick_start_4b/quick_start.sh` exists) → no-op, stay put.
2. **Repo already cloned as a subdirectory** of `$(pwd)` → `cd` in.
3. **Repo missing** → `git clone --depth 1` and `cd` in.

`OUTPUT_DIR` is moved to *after* the potential `cd` so it always resolves to the repo root.

The intro prose and requirements comment are updated accordingly:
- ``copy-paste this entire block from `<REPO_ROOT>`'' → ``copy-paste this entire block from any working directory''
- requirements comment now lists `git` alongside `docker` and `huggingface-cli`

## Why

I hit this concretely while running the fast path: my workspace was a data-prep directory (`./ov2_quickstart/` bundle already downloaded, docker image already loaded), but the repo wasn't cloned anywhere on the machine. The block failed because `$(pwd)/examples/...` didn't exist. Cloning is the one bootstrap step that wasn't covered by an existence check, so the ``re-runs safely'' promise had a gap on the first run.

Human readers were unaffected — §0–§5 already implicitly assume you've cloned. This change closes the gap for the agent block only.

## Compatibility

- Diff is **+18 / -4** lines in `README.md` only — no code, no scripts, no examples touched.
- Re-running the block is still safe: all three Step 0 branches are idempotent.
- Human walkthrough (§0–§5) is unchanged.
- Existing users who were already running from the repo root see no behavioral change (Step 0 short-circuits to the ``already inside repo root'' branch).