### PR TITLE
docs(readme): use HF remote paths and -tf57 ViT in Option B merge example

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ huggingface-cli download --repo-type dataset --resume-download \
 
 You'll need the standalone components from HF:
 
-- ViT: [`lmms-lab-encoder/onevision-encoder-large-lang`](https://huggingface.co/lmms-lab-encoder/onevision-encoder-large-lang) (or `-tf57` for the `p14m2` variant used here)
+- ViT: [`lmms-lab-encoder/onevision-encoder-large-lang-tf57`](https://huggingface.co/lmms-lab-encoder/onevision-encoder-large-lang-tf57) (the `p14m2` variant used here)
 - LLM: [`Qwen/Qwen3-4B-Instruct-2507`](https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507)
 - Processor: [`lmms-lab-encoder/LLaVA-OneVision-2-8B-Instruct`](https://huggingface.co/lmms-lab-encoder/LLaVA-OneVision-2-8B-Instruct) (tokenizer + processor configs)
 
@@ -315,8 +315,8 @@ Inside the container (set up in step 3), run **HF merge → Megatron conversion*
 # Stage 1: merge ViT + LLM + processor → unified HF checkpoint
 PYTHONPATH=transformers_impl:. python -m merge_ov2 merge \
     --variant dense \
-    --vit /path/to/onevision-encoder-large-lang-tf57 \
-    --llm /path/to/Qwen3-4B-Instruct-2507 \
+    --vit lmms-lab-encoder/onevision-encoder-large-lang-tf57 \
+    --llm Qwen/Qwen3-4B-Instruct-2507 \
     --processor lmms-lab-encoder/LLaVA-OneVision-2-8B-Instruct \
     --out ./ov2_quickstart/ov_encoder_p14m22_qwen3_hf \
     --target-dtype bf16 \


### PR DESCRIPTION
## Summary

- Switch the **ViT reference** in the Option B section from `lmms-lab-encoder/onevision-encoder-large-lang` to `lmms-lab-encoder/onevision-encoder-large-lang-tf57`, since the `p14m2` variant the quickstart actually uses only works with the `-tf57` checkpoint. The non-`-tf57` aside has been dropped to avoid the trap where a copy-paste of the wrong repo silently produces a checkpoint the quickstart can't load.
- Replace the placeholder `/path/to/onevision-encoder-large-lang-tf57` and `/path/to/Qwen3-4B-Instruct-2507` arguments in the `merge_ov2` command with the actual HF repo IDs (`lmms-lab-encoder/onevision-encoder-large-lang-tf57`, `Qwen/Qwen3-4B-Instruct-2507`) so the block is copy-paste-runnable — `from_pretrained` will fetch them on first use.

## Why

Option B already takes the path of "I want to swap the ViT/LLM or reproduce from scratch" — making the user manually `huggingface-cli download` two repos and then patch a placeholder is unnecessary friction. And mentioning the non-`-tf57` ViT was actively misleading here because the downstream conversion script (`convert_4b_p14m2_hf_to_mcore.sh`) and the rest of the quickstart assume the `p14m2` layout.

## Verification

- Visually checked the rendered diff fits the surrounding block.
- No code paths changed; only README text.