### PR TITLE
docs: finalize OV2 citation, link badges to HF, simplify project theme switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ href="docs/page/assets/wechat.png">WeChat Group</a></b> 👈
 </p>
 
 <p align="center">
-🤗 <b>2 <a href="#models">Models</a></b> · <b><a href="#datasets">Datasets</a></b> · <b><a
+🤗 <b>2 <a href="https://huggingface.co/lmms-lab-encoder/LLaVA-OneVision-2-8B-Instruct">Models</a></b> · <b><a href="https://huggingface.co/datasets/mvp-lab/LLaVA-OneVision-2-Data">Datasets</a></b> · <b><a
 href="https://arxiv.org/pdf/2605.25979">Technical Report</a></b> · <b><a
 href="https://evolvinglmms-lab.github.io/LLaVA-OneVision-2/">HomePage</a></b> · <b><a
 href="https://huggingface.co/spaces/FeilongTang/OneVision-Encoder-Codec-View">Codec&nbsp;Playground</a></b> · <b><a
@@ -490,8 +490,8 @@ If you find *LLaVA-OneVision-2* useful in your research, please consider to cite
 
 ```
 @inproceedings{LLaVA-OneVision-2,
-  title={LLaVA-OneVision-2},
-  author={llava-onevision contributors},
+  title={LLaVA-OneVision-2: Towards Next-Generation Perceptual Intelligence},
+  author={An, Xiang and Xie, Yin and Tang, Feilong and Yan, Yunyao and Tan, Huajie and Zhu, Didi and Chen, Changrui and Zhao, Xiuwei and Qin, Bin and Yang, Kaicheng and Shen, Yifei and Zhang, Yuanhan and Zhang, Kaichen and Zhang, Wenkang and Cheng, Zheng and Zhang, Nansen and Wu, Chunsheng and Ge, Chunjiang and Ran, Zimin and Song, Dehua and Li, Chunyuan and Feng, Shikun and Hu, Ming and Chen, Zhangquan and Niu, Junbo and Li, Bo and Feng, Ziyong and Liu, Ziwei and Ge, Zongyuan and Deng, Jiankang},
   booktitle={arXiv},
   year={2026}
 }

--- a/docs/page/index.html
+++ b/docs/page/index.html
@@ -3557,6 +3557,20 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
   author={An, Xiang and Xie, Yin and Yang, Kaicheng and Zhang, Wenkang and Zhao, Xiuwei and Cheng, Zheng and Wang, Yirui and Xu, Songcen and Chen, Changrui and Wu, Chunsheng and Tan, Huajie and Li, Chunyuan and Yang, Jing and Yu, Jie and Wang, Xiyao and Qin, Bin and Wang, Yumeng and Yan, Zizhen and Feng, Ziyong and Liu, Ziwei and Li, Bo and Deng, Jiankang},
   booktitle={arXiv},
   year={2025}
+}
+
+@article{tang2026onevisionencoder,
+  title={OneVision-Encoder: Codec-Aligned Sparsity as a Foundational Principle for Multimodal Intelligence},
+  author={Tang, Feilong and An, Xiang and Yan, Yunyao and Xie, Yin and Qin, Bin and Yang, Kaicheng and Shen, Yifei and Zhang, Yuanhan and Li, Chunyuan and Feng, Shikun and Chen, Changrui and Tan, Huajie and Hu, Ming and Zhang, Manyuan and Li, Bo and Feng, Ziyong and Liu, Ziwei and Ge, Zongyuan and Deng, Jiankang},
+  journal={arXiv preprint arXiv:2602.08683},
+  year={2026}
+}
+
+@article{lillava,
+  title={LLaVA-OneVision: Easy Visual Task Transfer},
+  author={Li, Bo and Zhang, Yuanhan and Guo, Dong and Zhang, Renrui and Li, Feng and Zhang, Hao and Zhang, Kaichen and Zhang, Peiyuan and Li, Yanwei and Liu, Ziwei and Li, Chunyuan},
+  journal={Transactions on Machine Learning Research},
+  year={2024}
 }</div>
           <div style="margin-top:10px">
             <button class="copy-btn" data-copy-target="citation-bibtex">Copy BibTeX</button>

--- a/docs/page/index.html
+++ b/docs/page/index.html
@@ -143,7 +143,7 @@
               <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"></path></svg>
               <span class="i18n" data-lang="en">Code</span><span class="i18n" data-lang="zh">代码</span>
             </a>
-            <a href="https://cdn.jsdelivr.net/gh/anxiangsir/ov2_asset@main/LLaVA_OneVision_2.pdf" target="_blank" rel="noopener noreferrer">
+            <a href="https://arxiv.org/abs/2605.25979" target="_blank" rel="noopener noreferrer">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
               <span class="i18n" data-lang="en">Technical Report</span><span class="i18n" data-lang="zh">技术报告</span>
             </a>
@@ -3545,11 +3545,18 @@ print(processor.batch_decode(out, skip_special_tokens=True)[0])
           <h3 class="toc-heading" id="citation">
             <span class="i18n" data-lang="en">Citation</span><span class="i18n" data-lang="zh">引用</span>
           </h3>
-          <div class="citation-block" id="citation-bibtex">@article{llava_onevision_2_2026,
-  title   = {LLaVA-OneVision-2: Open Multimodal Training at Scale},
-  author  = {LLaVA-OneVision-2 Contributors},
-  journal = {arXiv preprint arXiv:TBD},
-  year    = {2026}
+          <div class="citation-block" id="citation-bibtex">@inproceedings{LLaVA-OneVision-2,
+  title={LLaVA-OneVision-2: Towards Next-Generation Perceptual Intelligence},
+  author={An, Xiang and Xie, Yin and Tang, Feilong and Yan, Yunyao and Tan, Huajie and Zhu, Didi and Chen, Changrui and Zhao, Xiuwei and Qin, Bin and Yang, Kaicheng and Shen, Yifei and Zhang, Yuanhan and Zhang, Kaichen and Zhang, Wenkang and Cheng, Zheng and Zhang, Nansen and Wu, Chunsheng and Ge, Chunjiang and Ran, Zimin and Song, Dehua and Li, Chunyuan and Feng, Shikun and Hu, Ming and Chen, Zhangquan and Niu, Junbo and Li, Bo and Feng, Ziyong and Liu, Ziwei and Ge, Zongyuan and Deng, Jiankang},
+  booktitle={arXiv},
+  year={2026}
+}
+
+@inproceedings{LLaVA-OneVision-1.5,
+  title={LLaVA-OneVision-1.5: Fully Open Framework for Democratized Multimodal Training},
+  author={An, Xiang and Xie, Yin and Yang, Kaicheng and Zhang, Wenkang and Zhao, Xiuwei and Cheng, Zheng and Wang, Yirui and Xu, Songcen and Chen, Changrui and Wu, Chunsheng and Tan, Huajie and Li, Chunyuan and Yang, Jing and Yu, Jie and Wang, Xiyao and Qin, Bin and Wang, Yumeng and Yan, Zizhen and Feng, Ziyong and Liu, Ziwei and Li, Bo and Deng, Jiankang},
+  booktitle={arXiv},
+  year={2025}
 }</div>
           <div style="margin-top:10px">
             <button class="copy-btn" data-copy-target="citation-bibtex">Copy BibTeX</button>

--- a/docs/page/projects/index.html
+++ b/docs/page/projects/index.html
@@ -18,12 +18,14 @@
   <body>
     <nav class="site-navbar">
       <a href="../index.html" class="nav-item" aria-label="Back to LLaVA-OneVision-2">&larr; Back to LLaVA-OneVision-2</a>
-      <div class="theme-switcher">
-        <button data-theme="blue" class="theme-dot active" style="--dot-color:#2563eb" aria-label="Blue theme"></button>
-        <button data-theme="dark" class="theme-dot" style="--dot-color:#0f172a" aria-label="Dark theme"></button>
-        <button data-theme="forest" class="theme-dot" style="--dot-color:#166534" aria-label="Forest theme"></button>
-        <button data-theme="warm" class="theme-dot" style="--dot-color:#d97706" aria-label="Warm theme"></button>
-        <button data-theme="mono" class="theme-dot" style="--dot-color:#171717" aria-label="Mono theme"></button>
+      <div class="theme-switcher" role="group" aria-label="Theme">
+        <span class="theme-thumb" aria-hidden="true"></span>
+        <button data-theme="blue" class="theme-seg active" aria-label="Light theme" aria-pressed="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+        </button>
+        <button data-theme="dark" class="theme-seg" aria-label="Dark theme" aria-pressed="false">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z"/></svg>
+        </button>
       </div>
       <button class="nav-item" type="button" id="lang-toggle">中文</button>
     </nav>
@@ -193,28 +195,34 @@
     </footer>
 
     <script>
-      const dots = document.querySelectorAll('.theme-dot');
+      const switcher = document.querySelector('.theme-switcher');
+      const dots = document.querySelectorAll('.theme-seg');
       const root = document.documentElement;
-      
+
+      function highlight(theme) {
+        if (switcher) switcher.setAttribute('data-active', theme === 'dark' ? 'dark' : 'blue');
+        dots.forEach(d => {
+          const isActive = d.getAttribute('data-theme') === theme;
+          d.classList.toggle('active', isActive);
+          d.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        });
+      }
+
       const savedTheme = localStorage.getItem('llava-onevision-2-theme');
       if (savedTheme) {
-        document.body.setAttribute('data-theme', savedTheme);
-        dots.forEach(d => {
-          if (d.getAttribute('data-theme') === savedTheme) {
-            d.classList.add('active');
-          } else {
-            d.classList.remove('active');
-          }
-        });
+        root.dataset.theme = savedTheme;
+        highlight(savedTheme);
+      } else {
+        const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        highlight(prefersDark ? 'dark' : 'blue');
       }
 
       dots.forEach(dot => {
         dot.addEventListener('click', () => {
           const theme = dot.getAttribute('data-theme');
-          document.body.setAttribute('data-theme', theme);
+          root.dataset.theme = theme;
           localStorage.setItem('llava-onevision-2-theme', theme);
-          dots.forEach(d => d.classList.remove('active'));
-          dot.classList.add('active');
+          highlight(theme);
         });
       });
 


### PR DESCRIPTION
## Summary

Documentation/site polish for LLaVA-OneVision-2:

- **Citation**: Update the OV2 BibTeX entry in both `README.md` and `docs/page/index.html` to the final title *"Towards Next-Generation Perceptual Intelligence"* with the full author list in `Lastname, Firstname` form. The homepage citation block now also includes the OV1.5 entry, matching the README.
- **Links**:
  - Homepage **Technical Report** link → `https://arxiv.org/abs/2605.25979` (was the temporary jsDelivr PDF mirror).
  - README OV2 **Models** badge → `https://huggingface.co/lmms-lab-encoder/LLaVA-OneVision-2-8B-Instruct`.
  - README OV2 **Datasets** badge → `https://huggingface.co/datasets/mvp-lab/LLaVA-OneVision-2-Data`.
- **Projects page theme switcher**: Reduce from five themes (blue/dark/forest/warm/mono) to the same **two** (light + dark) used on the OV2 homepage, porting the homepage's sliding-thumb markup and theme logic (sets `data-theme` on `<html>`, toggles `data-active`, honors saved theme / OS preference). Shares the existing `localStorage` key so the choice stays consistent across pages.

## Notes

- Demo media URLs under `cdn.jsdelivr.net/gh/anxiangsir/ov2_asset` are unchanged — only the single `LLaVA_OneVision_2.pdf` report link was repointed.
- Docs-only changes; no code paths affected.