### PR TITLE
Fix Chinese codec demo caption color

### DIFF
--- a/docs/page/index.html
+++ b/docs/page/index.html
@@ -2577,7 +2577,7 @@
             </div>
             <figcaption class="figure-caption">
               <span class="i18n" data-lang="en"><strong>Figure 1.</strong> A jump-rope sample rendered on the codec timeline. The uniform-frame view is held to its nearest frame among 128 evenly spaced samples, while the codec view follows dense selected evidence and highlights the retained patches in orange.</span>
-              <span class="i18n" data-lang="zh"><strong>图 1.</strong> 一个跳绳样本，按 codec 时间轴渲染。左侧均匀帧视图只显示 128 个均匀采样帧中的最近帧；右侧 codec 视图跟随更密集的选中证据，并用绿色框标出保留的 patch。</span>
+              <span class="i18n" data-lang="zh"><strong>图 1.</strong> 一个跳绳样本，按 codec 时间轴渲染。左侧均匀帧视图只显示 128 个均匀采样帧中的最近帧；右侧 codec 视图跟随更密集的选中证据，并用橙色框标出保留的 patch。</span>
             </figcaption>
           </figure>
         </section>


### PR DESCRIPTION
This PR fixes a small inconsistency in the Chinese caption for the codec demo. The English caption and the demo styling describe retained codec patches as orange, while the Chinese caption previously referred to them as green.