### PR TITLE
ci(community): pull --rebase before bot push to avoid fetch-first races

### DIFF
--- a/.github/workflows/reademe-contributors.yml
+++ b/.github/workflows/reademe-contributors.yml
@@ -57,4 +57,9 @@ jobs:
           fi
           git add "${paths[@]}"
           git commit -m "docs(readme): refresh contributors SVG"
-          git push
+          # Guard against a concurrent bot push landing on main between our
+          # checkout and our push (would otherwise fail with "fetch first").
+          # --autostash covers the case where the workflow file itself was
+          # edited in the same gap.
+          git pull --rebase --autostash origin main
+          git push origin HEAD:main

--- a/.github/workflows/update-community-json.yml
+++ b/.github/workflows/update-community-json.yml
@@ -58,7 +58,12 @@ jobs:
           fi
           git add "$path"
           git commit -m "docs(page): refresh community.json"
-          git push
+          # Daily cron and any other concurrent bot push (e.g. reademe-contributors)
+          # can land a commit on main between our checkout and our push. Without
+          # this rebase the push is rejected with "fetch first"; --autostash also
+          # covers the case where the workflow file itself was edited in that gap.
+          git pull --rebase --autostash origin main
+          git push origin HEAD:main
 
       # Deploy Pages in the same workflow. We intentionally do NOT re-checkout
       # between the push and these steps — the working tree still has the


### PR DESCRIPTION
## Failure

Run [27113298803](https://github.com/EvolvingLMMs-Lab/LLaVA-OneVision-2/actions/runs/27113298803) failed with:

```
! [rejected]        main -> main (fetch first)
error: failed to push some refs to 'https://github.com/EvolvingLMMs-Lab/LLaVA-OneVision-2'
```

**Cause**: the cron-triggered `update-community-json.yml` workflow checked out `96710e2` (the head of main right after #185 merged), built a new `community.json`, then tried to push. Meanwhile, the `reademe-contributors.yml` cron had already pushed `813c6cf` (a fresh contributors SVG) onto main. Push rejected.

The same race shape exists in `reademe-contributors.yml` — both bot workflows had no protection against a concurrent push landing on main during their run. With deploy steps now cascading off the push in `update-community-json.yml` (added in #185), this race has become user-visible (the daily refresh's deploy silently skipped).

## Fix

Add `git pull --rebase --autostash origin main` immediately before the `git push` in both workflows. `--autostash` also covers the case where the workflow file itself was edited in the same gap (otherwise the rebase refuses on a dirty working tree).

Switched the push to `git push origin HEAD:main` (was bare `git push`) to be explicit about what's being pushed where — defensible when the head and the target ref can disagree after a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)