### PR TITLE
docs(readme): add Glint Lab attribution and online experience link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@
 </p>
 
 <p align="center">
+  <em>The core work on this project was led by <b>Glint Lab</b>.
+  For an interactive online experience, visit
+  <a href="https://ve2s.ai/">ve2s.ai</a>.</em>
+</p>
+
+<p align="center">
 👉 <b><a
 href="asset/xiaohongshu_group.jpeg">Xiaohongshu Group</a></b> 👈
 </p>


### PR DESCRIPTION
## What
Adds a short intro paragraph to the top of the README noting who led the core work on this project and where to try it online.

## Change
Inserts a single centered paragraph directly beneath the project tagline (_Fully Open Framework for Democratized Multimodal Training_), above the resource badges, consistent with the existing layout:

> *The core work on this project was led by **Glint Lab**. For an interactive online experience, visit [ve2s.ai](https://ve2s.ai/).*

## Notes
- README-only change; no code or behavior impact.
