### PR TITLE
docs: remove stale placeholder-numbers footnote

### DIFF
--- a/docs/page/index.html
+++ b/docs/page/index.html
@@ -1951,7 +1951,6 @@
             </div>
             </div>
 
-            <!-- Sub-table 3: TBD - waiting for benchmark list from user -->
             <div class="bench-card">
               <div class="bench-caption">
               <span class="bench-caption-label">

--- a/docs/page/index.html
+++ b/docs/page/index.html
@@ -2429,10 +2429,6 @@
             </div>
             </div>
 
-            <p class="footnote">
-              <span class="i18n" data-lang="en">Replace placeholder numbers once measurements are available.</span>
-              <span class="i18n" data-lang="zh">数值就绪后请替换上述占位。</span>
-            </p>
           </div>
         </section>
 


### PR DESCRIPTION
## Summary
- Removed the bilingual footnote ("Replace placeholder numbers once measurements are available." / "数值就绪后请替换上述占位。") under the tracking benchmark table, since the table already has real measured values and the disclaimer is stale.

## Test plan
- [x] Opened `docs/page/index.html` locally in a browser and confirmed the footnote no longer renders under the tracking benchmark table, in both EN and ZH.