### PR TITLE
deps: bump nltk to 3.10.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ megatron-energon==5.0.0
 mdformat==1.0.0
 mdformat-gfm==1.0.0
 mdformat-pyproject==0.1.1
-nltk==3.9.1
+nltk==3.10.3
 omegaconf==2.3.0
 pandarallel==1.6.5
 pre-commit==3.2.2


### PR DESCRIPTION
Updates `nltk` to address the advisories listed below.

Evidence:
- `requirements.txt` pinned `nltk@3.9.1`
- `osv-scanner` reported PYSEC-2026-96, PYSEC-2026-97, PYSEC-2026-98, PYSEC-2026-99, PYSEC-2026-2078, PYSEC-2026-2085, PYSEC-2026-2235, PYSEC-2026-2236, PYSEC-2026-2237, PYSEC-2026-3581, PYSEC-2026-3582, PYSEC-2026-3583, PYSEC-2026-3584, PYSEC-2026-3657 and their linked GHSAs for `nltk@3.9.1`
- updated version: `3.10.3`

Validation:
- `osv-scanner --lockfile=requirements.txt` no longer reports any advisory for `nltk` after the update
- `pip install nltk==3.10.3` and `import nltk` pass in a clean venv
- the repo documents no runnable unit test command for this requirements file, so no test suite was executed

Note: `osv-scanner` still reports separate advisories for other packages in `requirements.txt` (datasets, protobuf, sentencepiece, and others). This patch only clears the nltk advisories.

Scope: dependency/lockfile update only.
